### PR TITLE
Fix GPT response limit configuration

### DIFF
--- a/config.py
+++ b/config.py
@@ -58,8 +58,8 @@ GPT_TOP_P = min(1.0, max(0.0, _parse_float(os.getenv("GPT_TOP_P"), 1.0)))
 GPT_MAX_TOKENS = max(0, _parse_int(os.getenv("GPT_MAX_TOKENS"), 0))
 GPT_MESSAGE_COST = _parse_float(os.getenv("GPT_MESSAGE_COST", "1.2"), 1.2)
 
-GPT_RESPONSE_CHAR_LIMIT = max(0, _parse_int(os.getenv("GPT_RESPONSE_CHAR_LIMIT", "600"), 600))
-
- main
-GPT_RESPONSE_CHAR_LIMIT = max(0, _parse_int(os.getenv("GPT_RESPONSE_CHAR_LIMIT", "1200"), 1200))
+GPT_RESPONSE_CHAR_LIMIT = max(
+    0,
+    _parse_int(os.getenv("GPT_RESPONSE_CHAR_LIMIT", "1200"), 1200),
+)
 


### PR DESCRIPTION
## Summary
- remove stray token that broke the module import and consolidate the GPT_RESPONSE_CHAR_LIMIT setting into a single definition
- default the GPT response character limit to 1200 characters in one place

## Testing
- python -m compileall config.py

------
https://chatgpt.com/codex/tasks/task_e_68cd2493d3e48332aec89f18997247ec