### PR TITLE
Fix GPT API key resolution to return valid keys

### DIFF
--- a/modules/gpt/service.py
+++ b/modules/gpt/service.py
@@ -179,13 +179,14 @@ def resolve_gpt_api_key(force_refresh: bool = False) -> str:
             candidate = _extract_api_key(value, allow_loose=True)
             if candidate:
                 _cached_api_key = candidate
+                return candidate
 
     for key_name in ("GPT_API", "GPT_API_KEY", "OPENAI_API_KEY"):
         for variant in {key_name, key_name.lower()}:
             value = db.get_setting(variant)
             candidate = _extract_api_key(value, allow_loose=True)
             if candidate:
- main
+                _cached_api_key = candidate
                 return candidate
 
     try:
@@ -201,10 +202,7 @@ def resolve_gpt_api_key(force_refresh: bool = False) -> str:
         allow_loose = key_name in _COMMON_KEY_NAMES or any(term in key_name for term in ("gpt", "openai"))
         candidate = _extract_api_key(value, allow_loose=allow_loose)
         if candidate:
- codex/activate-gpt-api-access-for-all-users-nc4le1
             _cached_api_key = candidate
-
- main
             return candidate
 
     # در نهایت، تمام مقادیر باقی‌مانده را با قواعد سخت‌گیرانه بررسی می‌کنیم
@@ -214,10 +212,7 @@ def resolve_gpt_api_key(force_refresh: bool = False) -> str:
             _cached_api_key = candidate
             return candidate
 
- codex/activate-gpt-api-access-for-all-users-nc4le1
     _cached_api_key = ""
-
- main
     return ""
 
 


### PR DESCRIPTION
## Summary
- ensure resolve_gpt_api_key returns as soon as a valid key is found and caches it
- remove stray merge artefacts that caused syntax errors during bot startup

## Testing
- python -m compileall modules/gpt/service.py

------
https://chatgpt.com/codex/tasks/task_e_68cd3cea75d0833293d5ed57ab3d6d5a