### PR TITLE
Add OpenAI Assistant mode for GPT menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 برای فعال‌سازی دستیار GPT داخل ربات تلگرام متغیرهای محیطی زیر را مقداردهی کنید:
 
 - `GPT_API` یا `GPT_API_KEY` یا `OPENAI_API_KEY` — کلید دسترسی به سرویس GPT (الزامی).
-- `GPT_API_URL` — آدرس سرویس چت، پیش‌فرض `https://api.openai.com/v1/chat/completions`.
+- `GPT_MODE` — نوع سرویس GPT؛ مقدار `assistant` از OpenAI Assistants/Responses استفاده می‌کند (پیش‌فرض `chat`).
+- `GPT_API_URL` — آدرس سرویس چت؛ برای حالت `assistant` به‌صورت پیش‌فرض `https://api.openai.com/v1/responses` است.
 - `GPT_MODEL` — نام مدل، پیش‌فرض `gpt-4o-mini`.
 - `GPT_API_TIMEOUT` — زمان انتظار درخواست بر حسب ثانیه، پیش‌فرض `45`.
 - `GPT_API_KEY_HEADER` و `GPT_API_KEY_PREFIX` — در صورت نیاز به هدر سفارشی برای کلید.
@@ -14,6 +15,9 @@
 - `GPT_TEMPERATURE` — میزان خلاقیت پاسخ‌ها (۰ تا ۲، پیش‌فرض `0.7`).
 - `GPT_TOP_P` — مقدار `top_p` برای نمونه‌گیری هسته‌ای (۰ تا ۱، پیش‌فرض `1`).
 - `GPT_MAX_TOKENS` — سقف توکن برای هر پاسخ (۰ یعنی بدون محدودیت جداگانه).
+- `GPT_ASSISTANT_ID` — در صورت استفاده از Assistants API می‌توانید شناسه دستیار از پیش ساخته‌شده را وارد کنید (اختیاری).
+
+در صورتی که بخواهید ربات از OpenAI Assistant/Responses استفاده کند، کافی است متغیر `GPT_MODE=assistant` را تنظیم کنید. در این حالت، پیام‌ها همانند قبل از تاریخچه محلی ساخته شده و به اندپوینت جدید (`/v1/responses`) ارسال می‌شوند و در صورت وجود `GPT_ASSISTANT_ID` همان دستیار از پیش ساخته‌شده اجرا خواهد شد.
 
 ## امکانات ربات
 

--- a/config.py
+++ b/config.py
@@ -56,13 +56,32 @@ GPT_API_KEY = _first_non_empty(
     os.getenv("GPT_API_KEY"),
     os.getenv("OPENAI_API_KEY"),
 ).strip()
-GPT_API_URL = (os.getenv("GPT_API_URL") or "https://api.openai.com/v1/chat/completions").strip()
+
+_GPT_MODE_RAW = (
+    os.getenv("GPT_MODE")
+    or os.getenv("GPT_PROVIDER")
+    or os.getenv("GPT_API_MODE")
+    or "chat"
+)
+_GPT_MODE_NORMALISED = (_GPT_MODE_RAW or "").strip().lower()
+if _GPT_MODE_NORMALISED in {"assistant", "assistants", "assistant-api", "assistant_api", "responses", "response"}:
+    GPT_MODE = "assistant"
+else:
+    GPT_MODE = "chat"
+
+_DEFAULT_CHAT_API_URL = "https://api.openai.com/v1/chat/completions"
+_DEFAULT_ASSISTANT_API_URL = "https://api.openai.com/v1/responses"
+_default_url = _DEFAULT_ASSISTANT_API_URL if GPT_MODE == "assistant" else _DEFAULT_CHAT_API_URL
+
+GPT_API_URL = (os.getenv("GPT_API_URL") or _default_url).strip() or _default_url
 GPT_MODEL = (os.getenv("GPT_MODEL") or "gpt-4o-mini").strip() or "gpt-4o-mini"
 GPT_API_TIMEOUT = _parse_float(os.getenv("GPT_API_TIMEOUT", "45"), 45.0)
 GPT_API_KEY_HEADER = (os.getenv("GPT_API_KEY_HEADER") or "Authorization").strip() or "Authorization"
 GPT_API_KEY_PREFIX = os.getenv("GPT_API_KEY_PREFIX")
 if GPT_API_KEY_PREFIX is None:
     GPT_API_KEY_PREFIX = "Bearer "
+
+GPT_ASSISTANT_ID = (os.getenv("GPT_ASSISTANT_ID") or os.getenv("OPENAI_ASSISTANT_ID") or "").strip()
 
 _DEFAULT_SYSTEM_PROMPT = (
     "You are Vexa GPT. Reply in the user's language with concise, direct answers."


### PR DESCRIPTION
## Summary
- add configuration flag to toggle between legacy chat completions and the OpenAI Assistants/Responses API
- adjust GPT service payload/header handling to support the new assistant mode and parse its responses
- document the new GPT_MODE and optional GPT_ASSISTANT_ID environment variables for configuring the bot

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cd55b8bd5c8332a036058752c5de8a