### PR TITLE
Fix GPT web search results extraction

### DIFF
--- a/modules/gpt/service.py
+++ b/modules/gpt/service.py
@@ -518,6 +518,7 @@ def web_search(query: str, max_results: int = 3) -> List[Dict[str, str]]:
             if text or url:
                 results.append({"title": title, "url": url, "snippet": text})
 
+    _collect(payload.get("Results") or [])
     _collect(payload.get("RelatedTopics") or [])
 
     trimmed = results[: max_results if max_results and max_results > 0 else 3]


### PR DESCRIPTION
## Summary
- include DuckDuckGo `Results` entries when building GPT web search snippets

## Testing
- python -m compileall modules/gpt/service.py

------
https://chatgpt.com/codex/tasks/task_e_68cd66045f74833287fe61d3c2e9cca6