### PR TITLE
Add /language command and prompt users to select language

### DIFF
--- a/modules/home/handlers.py
+++ b/modules/home/handlers.py
@@ -142,6 +142,10 @@ def register(bot):
                 edit_or_send(bot, msg.chat.id, msg.message_id, txt, kb); return
 
         _handle_referral(bot, msg, user)
+        bot.send_message(
+            msg.chat.id,
+            "Please choose your language first.\nUse <code>/language</code> to open the language menu."
+        )
         current_state = db.get_state(user["user_id"]) or ""
         if current_state:
             db.clear_state(user["user_id"])

--- a/modules/lang/handlers.py
+++ b/modules/lang/handlers.py
@@ -7,7 +7,18 @@ from modules.home.texts import MAIN
 from modules.home.keyboards import main_menu
 from modules.i18n import t
 
+
+def _send_language_menu(bot, user, chat_id, message_id):
+    lang = db.get_user_lang(user["user_id"], "fa")
+    edit_or_send(bot, chat_id, message_id, TITLE(lang), lang_menu(lang, lang))
+
+
 def register(bot):
+    @bot.message_handler(commands=["language"])
+    def language_cmd(msg):
+        user = db.get_or_create_user(msg.from_user)
+        _send_language_menu(bot, user, msg.chat.id, msg.message_id)
+
     @bot.callback_query_handler(func=lambda c: c.data and c.data.startswith("lang:"))
     def lang_router(cq):
         user = db.get_or_create_user(cq.from_user)
@@ -27,7 +38,7 @@ def register(bot):
             edit_or_send(bot, cq.message.chat.id, cq.message.message_id, MAIN(lang), main_menu(lang))
             return
 
+
 def open_language(bot, cq):
     user = db.get_or_create_user(cq.from_user)
-    lang = db.get_user_lang(user["user_id"], "fa")
-    edit_or_send(bot, cq.message.chat.id, cq.message.message_id, TITLE(lang), lang_menu(lang, lang))
+    _send_language_menu(bot, user, cq.message.chat.id, cq.message.message_id)


### PR DESCRIPTION
## Summary
- add a /language command handler that opens the language menu for chat messages and reuse a helper for callbacks
- send an English prompt on /start to instruct users to choose their language via /language before showing the main menu

## Testing
- python -m compileall modules/home/handlers.py modules/lang/handlers.py

------
https://chatgpt.com/codex/tasks/task_e_68cdb68e369c8332b508efb507321a9c