### PR TITLE
Fix duplicate voice clone button in home menu

### DIFF
--- a/modules/home/keyboards.py
+++ b/modules/home/keyboards.py
@@ -14,10 +14,6 @@ def main_menu(lang: str) -> InlineKeyboardMarkup:
         InlineKeyboardButton(t("btn_profile", lang), callback_data="home:profile"),
         InlineKeyboardButton(t("btn_invite", lang), callback_data="home:invite"),
     )
-    kb.row(
-        InlineKeyboardButton(t("btn_credit", lang), callback_data="home:credit"),
-        InlineKeyboardButton(t("btn_clone", lang), callback_data="home:clone"),
-    )
     if lang == "fa":
         kb.row(
             InlineKeyboardButton(t("btn_credit", lang), callback_data="home:credit"),


### PR DESCRIPTION
## Summary
- remove the duplicate credit/voice clone row from the Farsi home menu keyboard so the voice clone button only appears once

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce39437bfc83328c52b2b687d7c02e