### PR TITLE
Fix duplicate home menu buttons

### DIFF
--- a/modules/home/keyboards.py
+++ b/modules/home/keyboards.py
@@ -18,13 +18,6 @@ def main_menu(lang: str) -> InlineKeyboardMarkup:
         InlineKeyboardButton(t("btn_credit", lang), callback_data="home:credit"),
         InlineKeyboardButton(t("btn_clone", lang), callback_data="home:clone"),
     )
-    if lang == "fa":
-        kb.row(
-            InlineKeyboardButton(t("btn_credit", lang), callback_data="home:credit"),
-            InlineKeyboardButton(t("btn_clone", lang), callback_data="home:clone"),
-        )
-    else:
-        kb.add(InlineKeyboardButton(t("btn_clone", lang), callback_data="home:clone"))
     kb.add(InlineKeyboardButton(t("btn_lang", lang), callback_data="home:lang"))
     return kb
 


### PR DESCRIPTION
## Summary
- remove duplicate credit and personal voice clone buttons from the home menu keyboard

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ce400684a88332803af459a0024bf3