### PR TITLE
Remove duplicate back buttons in credit payment menus

### DIFF
--- a/modules/credit/keyboards.py
+++ b/modules/credit/keyboards.py
@@ -30,7 +30,6 @@ def payrial_plans_kb(lang: str = "fa") -> InlineKeyboardMarkup:
             row = []
     
     kb.add(InlineKeyboardButton(t("back", lang), callback_data="credit:menu"))
-    kb.add(InlineKeyboardButton(t("back", "fa"), callback_data="credit:menu"))
     return kb
 
 def admin_approve_kb(user_id: int, plan_index: int) -> InlineKeyboardMarkup:
@@ -68,7 +67,6 @@ def stars_packages_kb(lang: str) -> InlineKeyboardMarkup:
         kb.row(*row)
 
     kb.add(InlineKeyboardButton(t("back", lang), callback_data="credit:menu"))
-    kb.add(InlineKeyboardButton(t("back", "fa"), callback_data="credit:menu"))
     return kb
 
 def instant_cancel_kb(lang: str = "fa") -> InlineKeyboardMarkup:


### PR DESCRIPTION
## Summary
- remove the extra back button from the rial payment plan keyboard
- remove the extra back button from the Telegram Stars packages keyboard

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce5b82ebf08332a0ae0a8b46d10368