### PR TITLE
Add admin reset button to unsubscribe users

### DIFF
--- a/db.py
+++ b/db.py
@@ -256,6 +256,24 @@ def log_message(user_id, direction, text):
         con.commit()
 
 
+def reset_user(user_id: int) -> bool:
+    """Completely remove a user and all related data from the bot database."""
+    with closing(sqlite3.connect(DB_PATH)) as con:
+        cur = con.cursor()
+        cur.execute("SELECT 1 FROM users WHERE user_id=?", (user_id,))
+        if not cur.fetchone():
+            return False
+
+        cur.execute("DELETE FROM users WHERE user_id=?", (user_id,))
+        cur.execute("DELETE FROM kv_state WHERE user_id=?", (user_id,))
+        cur.execute("DELETE FROM messages WHERE user_id=?", (user_id,))
+        cur.execute("DELETE FROM gpt_messages WHERE user_id=?", (user_id,))
+        cur.execute("DELETE FROM purchases WHERE user_id=?", (user_id,))
+        cur.execute("DELETE FROM user_voices WHERE user_id=?", (user_id,))
+        con.commit()
+    return True
+
+
 def log_gpt_message(user_id: int, role: str, content: str) -> None:
     role_value = str(role or "assistant").strip() or "assistant"
     with closing(sqlite3.connect(DB_PATH)) as con:

--- a/modules/admin/handlers.py
+++ b/modules/admin/handlers.py
@@ -10,6 +10,7 @@ from .texts import (
     TITLE, MENU, DENY, DONE,
     ASK_UID_ADD, ASK_AMT_ADD, STATE_ADD_UID, STATE_ADD_AMT,
     ASK_UID_SUB, ASK_AMT_SUB, STATE_SUB_UID, STATE_SUB_AMT,
+    ASK_UID_RESET, STATE_RESET_UID,
     ASK_UID_MSG, ASK_TXT_MSG, STATE_MSG_UID, STATE_MSG_TXT,
     ASK_TXT_CAST, STATE_CAST_TXT,
     ASK_UID_LOOKUP, STATE_USER_LOOKUP,
@@ -242,6 +243,12 @@ def register(bot):
             edit_or_send(bot, cq.message.chat.id, cq.message.message_id, ASK_UID_SUB, admin_menu())
             return
 
+        if action == "reset":
+            db.clear_state(cq.from_user.id)
+            db.set_state(cq.from_user.id, STATE_RESET_UID)
+            edit_or_send(bot, cq.message.chat.id, cq.message.message_id, ASK_UID_RESET, admin_menu())
+            return
+
         # از صفحه کاربر—رفتن مستقیم به مقدار
         if action == "uadd":
             uid = int(p[2])
@@ -425,6 +432,17 @@ def register(bot):
         db.add_credits(uid, -amt)
         newc = db.get_user(uid)["credits"]
         bot.reply_to(msg, f"{DONE}\n👤 <code>{uid}</code>\n➖ -{amt}💳\n💼 موجودی: <b>{newc}</b>")
+        db.clear_state(msg.from_user.id)
+
+    @bot.message_handler(func=lambda m: db.get_state(m.from_user.id) == STATE_RESET_UID, content_types=['text'])
+    def s_reset(msg: types.Message):
+        if not _is_owner(msg.from_user): return
+        uid = _resolve_user_id(msg.text)
+        if not uid:
+            bot.reply_to(msg, "❌ آی‌دی/یوزرنیم معتبر نیست."); return
+        if not db.reset_user(uid):
+            bot.reply_to(msg, "❌ کاربری با این مشخصات یافت نشد یا قبلاً حذف شده است."); return
+        bot.reply_to(msg, f"{DONE}\n👤 <code>{uid}</code>\n♻️ اطلاعات کاربر حذف شد و باید دوباره استارت کند.")
         db.clear_state(msg.from_user.id)
 
     # پیام تکی

--- a/modules/admin/keyboards.py
+++ b/modules/admin/keyboards.py
@@ -13,6 +13,7 @@ def admin_menu():
         InlineKeyboardButton("➕ افزودن کردیت", callback_data="admin:add"),
         InlineKeyboardButton("➖ کسر کردیت", callback_data="admin:sub"),
     )
+    kb.add(InlineKeyboardButton("♻️ ریست کاربر", callback_data="admin:reset"))
     kb.row(
         InlineKeyboardButton("✉️ پیام تکی", callback_data="admin:dm"),
         InlineKeyboardButton("📣 پیام همگانی", callback_data="admin:cast"),

--- a/modules/admin/texts.py
+++ b/modules/admin/texts.py
@@ -28,6 +28,10 @@ STATE_SUB_UID = "ADMIN:SUB:UID"
 ASK_AMT_SUB   = "➖ مقدار کردیتی که باید کم شود را بفرستید (فقط عدد)."
 STATE_SUB_AMT = "ADMIN:SUB:AMT"
 
+# ——— ریست/آن‌سابسکرایب کاربر
+ASK_UID_RESET   = "♻️ آیدی عددی یا یوزرنیم کاربری که باید ریست شود را بفرستید."
+STATE_RESET_UID = "ADMIN:RESET:UID"
+
 # ——— پیام تکی
 ASK_UID_MSG   = "✉️ آیدی عددی یا یوزرنیم کاربری که باید پیام تکی بگیرد را بفرستید."
 STATE_MSG_UID = "ADMIN:DM:UID"


### PR DESCRIPTION
## Summary
- add a reset option in the admin panel to request a user id for unsubscribing
- wire the new state handler that removes all user data and prompts a restart
- implement `db.reset_user` to clear database rows tied to the target user

## Testing
- python -m compileall db.py modules/admin

------
https://chatgpt.com/codex/tasks/task_e_68cef0629aa08332b802a5523de4e37d