### PR TITLE
Prompt language selection after force subscription

### DIFF
--- a/modules/home/handlers.py
+++ b/modules/home/handlers.py
@@ -165,7 +165,15 @@ def register(bot):
             settings = db.get_settings()
             ok, txt, kb = check_force_sub(bot, user["user_id"], settings)
             if ok:
-                edit_or_send(bot, cq.message.chat.id, cq.message.message_id, MAIN(lang), main_menu(lang))
+                from modules.lang.handlers import send_language_menu
+
+                send_language_menu(
+                    bot,
+                    user,
+                    cq.message.chat.id,
+                    cq.message.message_id,
+                    display_lang="en",
+                )
                 bot.answer_callback_query(cq.id, t("force_sub_confirmed", lang))
             else:
                 bot.answer_callback_query(cq.id, t("force_sub_not_joined", lang))

--- a/modules/lang/handlers.py
+++ b/modules/lang/handlers.py
@@ -1,4 +1,6 @@
 # modules/lang/handlers.py
+from typing import Optional
+
 import db
 from utils import edit_or_send
 from .texts import TITLE
@@ -8,13 +10,21 @@ from modules.home.keyboards import main_menu
 from modules.i18n import t
 
 
-def _language_menu_content(user):
-    lang = db.get_user_lang(user["user_id"], "fa")
-    return TITLE(lang), lang_menu(lang, lang), lang
+def _language_menu_content(user, display_lang: Optional[str] = None):
+    user_lang = db.get_user_lang(user["user_id"], "fa")
+    render_lang = display_lang or user_lang
+    return TITLE(render_lang), lang_menu(user_lang, render_lang), user_lang
 
 
-def _send_language_menu(bot, user, chat_id, message_id=None, force_new=False):
-    text, markup, _ = _language_menu_content(user)
+def send_language_menu(
+    bot,
+    user,
+    chat_id,
+    message_id=None,
+    force_new: bool = False,
+    display_lang: Optional[str] = None,
+):
+    text, markup, _ = _language_menu_content(user, display_lang)
     if force_new or message_id is None:
         bot.send_message(chat_id, text, reply_markup=markup, parse_mode="HTML")
     else:
@@ -25,7 +35,7 @@ def register(bot):
     @bot.message_handler(commands=["language"])
     def language_cmd(msg):
         user = db.get_or_create_user(msg.from_user)
-        _send_language_menu(bot, user, msg.chat.id, force_new=True)
+        send_language_menu(bot, user, msg.chat.id, force_new=True)
 
     @bot.callback_query_handler(func=lambda c: c.data and c.data.startswith("lang:"))
     def lang_router(cq):
@@ -49,4 +59,4 @@ def register(bot):
 
 def open_language(bot, cq):
     user = db.get_or_create_user(cq.from_user)
-    _send_language_menu(bot, user, cq.message.chat.id, cq.message.message_id)
+    send_language_menu(bot, user, cq.message.chat.id, cq.message.message_id)


### PR DESCRIPTION
## Summary
- add a reusable helper that can render the language selection menu in a requested locale
- show the language picker in English after a user confirms forced subscription

## Testing
- python -m compileall modules/home/handlers.py modules/lang/handlers.py

------
https://chatgpt.com/codex/tasks/task_e_68cef91edd8883328c911daa92db717a