### PR TITLE
Fix duplicate cancel button in credit receipt flow

### DIFF
--- a/modules/credit/keyboards.py
+++ b/modules/credit/keyboards.py
@@ -72,5 +72,4 @@ def stars_packages_kb(lang: str) -> InlineKeyboardMarkup:
 def instant_cancel_kb(lang: str = "fa") -> InlineKeyboardMarkup:
     kb = InlineKeyboardMarkup(row_width=1)
     kb.add(InlineKeyboardButton(t("credit_cancel", lang), callback_data="credit:cancel"))
-    kb.add(InlineKeyboardButton(t("credit_cancel", "fa"), callback_data="credit:cancel"))
     return kb


### PR DESCRIPTION
## Summary
- remove the redundant duplicate cancel button from the instant cancel keyboard so the receipt flow only shows one cancel action

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf026846f4833280d9c25822b8a864