### PR TITLE
Fix Runway API key handling

### DIFF
--- a/config.py
+++ b/config.py
@@ -15,7 +15,9 @@ load_dotenv(Path(__file__).resolve().parent / ".env")
 
 BOT_TOKEN = os.getenv("BOT_TOKEN")
 ELEVEN_API_KEY = os.getenv("ELEVEN_API_KEY")
-RUNWAY_API_KEY = os.getenv("RUNWAY_API") or os.getenv("RUNWAY_API_KEY")
+RUNWAY_API = (os.getenv("RUNWAY_API") or "").strip()
+# Backwards compatibility: some modules still import RUNWAY_API_KEY.
+RUNWAY_API_KEY = RUNWAY_API
 CARD_NUMBER = os.getenv("CARD_NUMBER", "****-****-****-****")
 
 try:


### PR DESCRIPTION
## Summary
- expose the Runway credential under the RUNWAY_API name in config and keep a compatibility alias
- update the image generation service to read only RUNWAY_API, improve the auth header, and clarify error text

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cfe342fc1483329c037ffa5d4a2526