### PR TITLE
Fix Runway API key detection for image generation

### DIFF
--- a/config.py
+++ b/config.py
@@ -15,7 +15,8 @@ load_dotenv(Path(__file__).resolve().parent / ".env")
 
 BOT_TOKEN = os.getenv("BOT_TOKEN")
 ELEVEN_API_KEY = os.getenv("ELEVEN_API_KEY")
-RUNWAY_API = (os.getenv("RUNWAY_API") or "").strip()
+_RUNWAY_API_RAW = os.getenv("RUNWAY_API") or os.getenv("RUNWAY_API_KEY")
+RUNWAY_API = (_RUNWAY_API_RAW or "").strip()
 # Backwards compatibility: some modules still import RUNWAY_API_KEY.
 RUNWAY_API_KEY = RUNWAY_API
 CARD_NUMBER = os.getenv("CARD_NUMBER", "****-****-****-****")

--- a/modules/image/service.py
+++ b/modules/image/service.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, Iterable, Optional
 import requests
 
 # ===== Config (ENV) =====
-RUNWAY_API = (os.getenv("RUNWAY_API") or "").strip()
+RUNWAY_API = (os.getenv("RUNWAY_API") or os.getenv("RUNWAY_API_KEY") or "").strip()
 
 RUNWAY_MODEL = (os.getenv("RUNWAY_MODEL") or "gen4_image").strip()
 RUNWAY_API_URL = (os.getenv("RUNWAY_API_URL") or "https://api.runwayml.com/v1/tasks").strip()


### PR DESCRIPTION
## Summary
- allow configuring the Runway client via the RUNWAY_API_KEY environment variable
- update the shared config so both RUNWAY_API and RUNWAY_API_KEY env vars are accepted

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cff37d028c8332a92907b6f6fd883b