### PR TITLE
Fix image generation handlers

### DIFF
--- a/modules/image/handlers.py
+++ b/modules/image/handlers.py
@@ -1,24 +1,30 @@
-
 # modules/image/handlers.py
-"""Telegram handlers for Runway image generation (menu button + /img)."""
+"""Telegram handlers for the Runway image generation flow."""
 
 from __future__ import annotations
 
+from typing import Any
+
 import db
 from telebot import TeleBot
-from telebot.types import CallbackQuery, ForceReply, Message
+from telebot.types import CallbackQuery, Message
 
+from modules.home.keyboards import main_menu
+from modules.home.texts import MAIN
+from modules.i18n import t
 from utils import edit_or_send
 from .keyboards import menu_keyboard, no_credit_keyboard
-from .service import ImageService, ImageGenerationError
-from .settings import CREDIT_COST
+from .service import ImageGenerationError, ImageService
+from .settings import CREDIT_COST, POLL_INTERVAL, POLL_TIMEOUT, STATE_PROCESSING, STATE_WAIT_PROMPT
 from .texts import (
     error as error_text,
     intro,
     no_credit as no_credit_text,
     not_configured,
+    processing,
     result_caption,
 )
+
 
 USAGE = (
     "ساخت تصویر از متن:\n"
@@ -27,7 +33,6 @@ USAGE = (
     "یا از منوی ربات دکمهٔ «تولید تصویر» را بزن."
 )
 
-_WAITING: dict[int, bool] = {}
 
 def _extract_prompt(message: Message) -> str:
     text = (message.text or "").strip()
@@ -38,67 +43,163 @@ def _extract_prompt(message: Message) -> str:
         text = (message.reply_to_message.text or "").strip()
     return text
 
-def _ask_for_prompt(bot: TeleBot, chat_id: int, reply_to_message_id: int | None = None):
-    _WAITING[chat_id] = True
+
+def _get_user_and_lang(from_user):
+    user = db.get_or_create_user(from_user)
+    db.touch_last_seen(user["user_id"])
+    lang = db.get_user_lang(user["user_id"], "fa")
+    return user, lang
+
+
+def _start_prompt_flow(
+    bot: TeleBot,
+    chat_id: int,
+    user_id: int,
+    lang: str,
+    *,
+    message_id: int | None = None,
+    show_intro: bool = True,
+) -> None:
+    db.set_state(user_id, STATE_WAIT_PROMPT)
+    if not show_intro:
+        return
+    if message_id is not None:
+        edit_or_send(bot, chat_id, message_id, intro(lang), menu_keyboard(lang))
+    else:
+        bot.send_message(chat_id, intro(lang), reply_markup=menu_keyboard(lang), parse_mode="HTML")
+
+
+def _send_no_credit(bot: TeleBot, chat_id: int, lang: str, credits: int) -> None:
     bot.send_message(
         chat_id,
-        "✍️ متن تصویری که می‌خوای تولید بشه رو بفرست",
-        reply_to_message_id=reply_to_message_id,
-        reply_markup=ForceReply(selective=False),
+        no_credit_text(lang, credits),
+        reply_markup=no_credit_keyboard(lang),
         parse_mode="HTML",
     )
 
-def open_image(bot: TeleBot, call: CallbackQuery):
-    message = call.message
-    _ask_for_prompt(bot, message.chat.id, message.message_id)
 
-def handle_img(bot: TeleBot, message: Message):
-    user_id = message.from_user.id
-    prompt = _extract_prompt(message)
+def _extract_image_url(data: Any) -> str | None:
+    if isinstance(data, str):
+        return data
+    if isinstance(data, dict):
+        for key in ("image", "url"):
+            value = data.get(key)
+            if isinstance(value, str) and value:
+                return value
+        for key in ("images", "data", "output"):
+            value = data.get(key)
+            url = _extract_image_url(value)
+            if url:
+                return url
+    if isinstance(data, (list, tuple)):
+        for item in data:
+            url = _extract_image_url(item)
+            if url:
+                return url
+    return None
 
+
+def _process_prompt(bot: TeleBot, message: Message, user, prompt: str, lang: str) -> None:
+    prompt = (prompt or "").strip()
     if not prompt:
-        _ask_for_prompt(bot, message.chat.id, message.message_id)
-        return
-
-    credits = db.get_credits(user_id)
-    if credits < CREDIT_COST:
-        bot.send_message(
-            message.chat.id,
-            no_credit_text,
-            reply_markup=no_credit_keyboard(),
-            parse_mode="HTML",
-        )
+        _start_prompt_flow(bot, message.chat.id, user["user_id"], lang)
         return
 
     try:
         service = ImageService()
     except ImageGenerationError:
-        bot.send_message(message.chat.id, not_configured, parse_mode="HTML")
+        bot.send_message(message.chat.id, not_configured(lang), parse_mode="HTML")
+        _start_prompt_flow(bot, message.chat.id, user["user_id"], lang, show_intro=False)
         return
 
-    status = bot.send_message(message.chat.id, "⏳ در حال تولید تصویر...", parse_mode="HTML")
+    fresh = db.get_user(user["user_id"]) or user
+    credits = int(fresh.get("credits", 0) or 0)
+    if credits < CREDIT_COST:
+        _send_no_credit(bot, message.chat.id, lang, credits)
+        _start_prompt_flow(bot, message.chat.id, user["user_id"], lang, show_intro=False)
+        return
+
+    db.set_state(user["user_id"], STATE_PROCESSING)
+    status = bot.send_message(message.chat.id, processing(lang), parse_mode="HTML")
+
     try:
         task_id = service.generate_image(prompt)
-        result = service.get_image_status(task_id)
-        image_url = result[0]['image'] if result else None
-
+        result = service.get_image_status(task_id, poll_interval=POLL_INTERVAL, timeout=POLL_TIMEOUT)
+        image_url = _extract_image_url(result)
         if not image_url:
             raise ImageGenerationError("خروجی تصویر دریافت نشد.")
 
         bot.send_photo(
             message.chat.id,
             photo=image_url,
-            caption=result_caption,
+            caption=result_caption(lang),
             reply_to_message_id=message.message_id,
             parse_mode="HTML",
         )
-        db.decrease_credits(user_id, CREDIT_COST)
+        db.deduct_credits(user["user_id"], CREDIT_COST)
 
-    except ImageGenerationError as e:
-        bot.edit_message_text(
-            f"⚠️ خطا در تولید تصویر:
-<code>{str(e)}</code>",
-            chat_id=status.chat.id,
-            message_id=status.message_id,
-            parse_mode="HTML",
-        )
+        try:
+            bot.delete_message(status.chat.id, status.message_id)
+        except Exception:
+            pass
+
+    except ImageGenerationError as exc:
+        try:
+            bot.edit_message_text(
+                f"{error_text(lang)}\n<code>{exc}</code>",
+                chat_id=status.chat.id,
+                message_id=status.message_id,
+                parse_mode="HTML",
+            )
+        except Exception:
+            bot.send_message(message.chat.id, f"{error_text(lang)}\n<code>{exc}</code>", parse_mode="HTML")
+
+    finally:
+        _start_prompt_flow(bot, message.chat.id, user["user_id"], lang, show_intro=False)
+
+
+def open_image(bot: TeleBot, call: CallbackQuery) -> None:
+    user, lang = _get_user_and_lang(call.from_user)
+    if user.get("banned"):
+        bot.answer_callback_query(call.id, t("error_banned", lang), show_alert=True)
+        return
+    _start_prompt_flow(bot, call.message.chat.id, user["user_id"], lang, message_id=call.message.message_id)
+    bot.answer_callback_query(call.id)
+
+
+def handle_img(bot: TeleBot, message: Message) -> None:
+    user, lang = _get_user_and_lang(message.from_user)
+    if user.get("banned"):
+        bot.reply_to(message, t("error_banned", lang))
+        return
+
+    prompt = _extract_prompt(message)
+    if not prompt:
+        _start_prompt_flow(bot, message.chat.id, user["user_id"], lang)
+        return
+
+    _process_prompt(bot, message, user, prompt, lang)
+
+
+def register(bot: TeleBot) -> None:
+    @bot.callback_query_handler(func=lambda c: c.data == "image:back")
+    def on_back(cq: CallbackQuery):
+        user, lang = _get_user_and_lang(cq.from_user)
+        db.clear_state(user["user_id"])
+        edit_or_send(bot, cq.message.chat.id, cq.message.message_id, MAIN(lang), main_menu(lang))
+        bot.answer_callback_query(cq.id)
+
+    @bot.message_handler(commands=["img"])
+    def on_img_command(message: Message):
+        handle_img(bot, message)
+
+    @bot.message_handler(
+        func=lambda m: (db.get_state(m.from_user.id) or "").startswith(STATE_WAIT_PROMPT),
+        content_types=["text"],
+    )
+    def on_prompt(message: Message):
+        user, lang = _get_user_and_lang(message.from_user)
+        if message.text and message.text.startswith("/"):
+            return
+        _process_prompt(bot, message, user, message.text or "", lang)
+


### PR DESCRIPTION
## Summary
- rewrite the image generation handlers to register bot routes, manage state, and respect user language/credits
- improve Runway polling, error handling, and result parsing for image responses

## Testing
- python -m compileall modules/image

------
https://chatgpt.com/codex/tasks/task_e_68d018cdf6788332a7b2bace2ebdb96d