### PR TITLE
Handle Runway success status variants

### DIFF
--- a/modules/image/service.py
+++ b/modules/image/service.py
@@ -97,7 +97,8 @@ class ImageService:
                     raise ImageGenerationError(f"Invalid JSON in status response: {resp.text}")
 
                 status = data.get("status")
-                if status == "SUCCEEDED":
+                succeeded_statuses = {"SUCCEEDED", "COMPLETED", "TASK_STATUS_SUCCEEDED"}
+                if status and (status in succeeded_statuses or "SUCCEEDED" in str(status)):
                     output = data.get("output")
                     return output  # خروجی شامل لینک یا داده تصویر
                 if status == "FAILED":


### PR DESCRIPTION
## Summary
- handle additional Runway success status values when polling image generation results

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d022d578e48332bb82d920efd89653