### PR TITLE
Fix Runway image polling stuck in processing

### DIFF
--- a/modules/image/service.py
+++ b/modules/image/service.py
@@ -282,15 +282,16 @@ class ImageService:
                         error_msg = status_raw or "Unknown error from Runway during generation."
                     raise ImageGenerationError(f"Runway task failed ({status_raw}): {error_msg}")
 
-                # اگر موفقیت تشخیص داده شد، خروجی/URL یا assets را برگردان
-                if status_kind == "success":
-                    # 1) جستجوی URL در خود payload
-                    url = _extract_first_url(data)
+                # چه وضعیت موفقیت تشخیص داده شود و چه API خروجی را زودتر بدهد، سعی کن نتیجه را استخراج کنی
+                url = _extract_first_url(data)
+                output = _extract_first(data, OUTPUT_KEYS)
+
+                if status_kind == "success" or url or output is not None:
+                    # 1) اگر URL مستقیم داخل payload پیدا شد
                     if url:
                         return url
 
                     # 2) تلاش برای خروجی‌های متعارف
-                    output = _extract_first(data, OUTPUT_KEYS)
                     if output is not None:
                         if isinstance(output, str):
                             # ممکن است خودش URL یا data:image باشد


### PR DESCRIPTION
## Summary
- ensure the Runway image polling flow returns once an output URL is available even if no explicit success token is sent

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d03a1a49e8833294f1734358d1e29f