### PR TITLE
Add Runway version header for image generation

### DIFF
--- a/modules/image/service.py
+++ b/modules/image/service.py
@@ -32,6 +32,7 @@ class ImageService:
 
     _BASE_URL = "https://api.dev.runwayml.com/v1"
     _MODEL = "gen3a_turbo"
+    _API_VERSION = os.getenv("RUNWAY_API_VERSION", "2024-06-26")
     _DEFAULT_WIDTH = 1024
     _DEFAULT_HEIGHT = 1024
     _DEFAULT_FORMAT = "webp"
@@ -52,6 +53,7 @@ class ImageService:
                 "Content-Type": "application/json",
                 "Accept": "application/json",
                 "User-Agent": "vexa-ai-image-service/1.0",
+                "X-Runway-Version": self._API_VERSION,
             }
         )
 


### PR DESCRIPTION
## Summary
- add support for the Runway API version header required by the dev endpoint
- make the version configurable via the RUNWAY_API_VERSION environment variable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d048cf37408332918435597ce924fa