### PR TITLE
Restore dev Runway base URL by default

### DIFF
--- a/modules/image/service.py
+++ b/modules/image/service.py
@@ -30,8 +30,8 @@ class ImageGenerationError(RuntimeError):
 class ImageService:
     """Client for interacting with the Runway image generation API."""
 
-    _BASE_URL = "https://api.dev.runwayml.com/v1"
-    _MODEL = "gen4_image_turbo"
+    _BASE_URL = os.getenv("RUNWAY_API_URL") or "https://api.dev.runwayml.com/v1"
+    _MODEL = os.getenv("RUNWAY_MODEL", "gen4_image_turbo")
     _API_VERSION = os.getenv("RUNWAY_API_VERSION", "2024-11-06")
     _DEFAULT_WIDTH = 1024
     _DEFAULT_HEIGHT = 1024


### PR DESCRIPTION
## Summary
- default the Runway image service base URL back to the dev endpoint while still allowing overrides via RUNWAY_API_URL

## Testing
- python -m compileall modules/image/service.py

------
https://chatgpt.com/codex/tasks/task_e_68d04e2ff5d08332bd434297aa861dd6