### PR TITLE
Hide back option on initial language selection

### DIFF
--- a/modules/lang/handlers.py
+++ b/modules/lang/handlers.py
@@ -10,10 +10,17 @@ from modules.home.keyboards import main_menu
 from modules.i18n import t
 
 
-def _language_menu_content(user, display_lang: Optional[str] = None):
+def _language_menu_content(
+    user,
+    display_lang: Optional[str] = None,
+):
     stored_lang = (user or {}).get("lang") or ""
     render_lang = display_lang or stored_lang or "fa"
-    return TITLE(render_lang), lang_menu(stored_lang, render_lang), stored_lang or render_lang
+    return (
+        TITLE(render_lang),
+        lang_menu(stored_lang, render_lang, show_back=bool(stored_lang)),
+        stored_lang or render_lang,
+    )
 
 
 def send_language_menu(

--- a/modules/lang/keyboards.py
+++ b/modules/lang/keyboards.py
@@ -16,7 +16,7 @@ LANGS = [
 ]
 
 
-def lang_menu(current: str, lang: str) -> InlineKeyboardMarkup:
+def lang_menu(current: str, lang: str, *, show_back: bool = True) -> InlineKeyboardMarkup:
     kb = InlineKeyboardMarkup(row_width=2)
     row = []
     for label, code in LANGS:
@@ -27,6 +27,7 @@ def lang_menu(current: str, lang: str) -> InlineKeyboardMarkup:
             row = []
     if row:
         kb.row(*row)
-    kb.add(InlineKeyboardButton(t("back", lang), callback_data="lang:back"))
+    if show_back:
+        kb.add(InlineKeyboardButton(t("back", lang), callback_data="lang:back"))
     return kb
 


### PR DESCRIPTION
## Summary
- hide the back button in the language picker until a user has already saved a language
- add a `show_back` flag to the language keyboard builder to control the button visibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d11ae090ec8332a2166ce815a0ef54