### PR TITLE
Reorder main menu buttons

### DIFF
--- a/modules/home/keyboards.py
+++ b/modules/home/keyboards.py
@@ -7,20 +7,22 @@ from modules.i18n import t
 def main_menu(lang: str) -> InlineKeyboardMarkup:
     kb = InlineKeyboardMarkup()
     kb.row(
-        InlineKeyboardButton(t("btn_gpt", lang), callback_data="home:gpt_chat"),
-        InlineKeyboardButton(t("btn_image", lang), callback_data="home:image"),
+        InlineKeyboardButton(t("btn_profile", lang), callback_data="home:profile"),
+        InlineKeyboardButton(t("btn_credit", lang), callback_data="home:credit"),
     )
     kb.row(
         InlineKeyboardButton(t("btn_tts", lang), callback_data="home:tts"),
+    )
+    kb.row(
         InlineKeyboardButton(t("btn_clone", lang), callback_data="home:clone"),
     )
     kb.row(
-        InlineKeyboardButton(t("btn_profile", lang), callback_data="home:profile"),
-        InlineKeyboardButton(t("btn_invite", lang), callback_data="home:invite"),
+        InlineKeyboardButton(t("btn_image", lang), callback_data="home:image"),
+        InlineKeyboardButton(t("btn_gpt", lang), callback_data="home:gpt_chat"),
     )
     kb.row(
-        InlineKeyboardButton(t("btn_credit", lang), callback_data="home:credit"),
         InlineKeyboardButton(t("btn_lang", lang), callback_data="home:lang"),
+        InlineKeyboardButton(t("btn_invite", lang), callback_data="home:invite"),
     )
     return kb
 


### PR DESCRIPTION
## Summary
- reorder the main menu layout to prioritize profile and credit options in the first row
- arrange remaining actions into single- and double-button rows that match the requested order

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d11e96543483329d53d8c454b85d83