### PR TITLE
Move clone voice entry to TTS menu

### DIFF
--- a/modules/home/keyboards.py
+++ b/modules/home/keyboards.py
@@ -14,9 +14,6 @@ def main_menu(lang: str) -> InlineKeyboardMarkup:
         InlineKeyboardButton(t("btn_tts", lang), callback_data="home:tts"),
     )
     kb.row(
-        InlineKeyboardButton(t("btn_clone", lang), callback_data="home:clone"),
-    )
-    kb.row(
         InlineKeyboardButton(t("btn_image", lang), callback_data="home:image"),
         InlineKeyboardButton(t("btn_gpt", lang), callback_data="home:gpt_chat"),
     )

--- a/modules/tts/keyboards.py
+++ b/modules/tts/keyboards.py
@@ -31,13 +31,16 @@ def keyboard(selected_voice: str, lang: str = "fa", user_id: int = None):
                                  callback_data=f"tts:voice:{n}")
             for n in row
         ])
-    
+
     # اگر صدای انتخابی کاستوم هست، دکمه حذف اضافه کن
     if user_id and selected_voice:
         is_custom = any(voice[0] == selected_voice for voice in custom_voices)
         if is_custom:
             kb.add(InlineKeyboardButton("🗑 حذف این صدا", callback_data=f"tts:delete:{selected_voice}"))
-    
+
+    # دکمه ساخت صدای شخصی همیشه قبل از بازگشت باشد
+    kb.add(InlineKeyboardButton(t("btn_clone", lang), callback_data="home:clone"))
+
     kb.add(InlineKeyboardButton(t("back", lang), callback_data="home:back"))
     return kb
 


### PR DESCRIPTION
## Summary
- remove the voice clone button from the home menu
- add a dedicated "voice clone" row before the back button in the TTS keyboard so it is always accessible there

## Testing
- python -m compileall modules

------
https://chatgpt.com/codex/tasks/task_e_68d1246c3d088332a09d11b56c187f3a