### PR TITLE
Set GPT input placeholder to Vexa AI

### DIFF
--- a/modules/gpt/handlers.py
+++ b/modules/gpt/handlers.py
@@ -182,7 +182,20 @@ def _start_chat(
     if reset_history:
         db.clear_gpt_history(user_id)
     text = t("gpt_open", lang).format(cost=_format_credits(GPT_MESSAGE_COST))
-    edit_or_send(bot, chat_id, message_id, text, _chat_keyboard(lang))
+
+    if message_id is not None:
+        try:
+            bot.delete_message(chat_id, message_id)
+        except Exception:
+            pass
+
+    bot.send_message(
+        chat_id,
+        text,
+        reply_markup=_chat_keyboard(lang),
+        parse_mode="HTML",
+        input_field_placeholder="Vexa AI",
+    )
     return True
 
 


### PR DESCRIPTION
## Summary
- replace the GPT chat start message editing with a fresh send that applies a Vexa AI input placeholder
- remove the previous message when possible before posting the new GPT prompt

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1281c2a948332a8f474c3423fb121