### PR TITLE
Fix Runway image response parsing

### DIFF
--- a/modules/image/service.py
+++ b/modules/image/service.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import logging
 import os
 import time
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Iterable, Optional
 
 import requests
 
@@ -85,7 +85,7 @@ class ImageService:
         response = self._request("POST", "/tasks", json=payload)
         data = self._safe_json(response)
 
-        task_id = data.get("id") or data.get("task_id")
+        task_id = self._extract_task_id(data)
         if not task_id:
             raise ImageGenerationError("شناسهٔ تسک از پاسخ Runway دریافت نشد.")
 
@@ -111,7 +111,7 @@ class ImageService:
             response = self._request("GET", f"/tasks/{task_id}")
             payload = self._safe_json(response)
 
-            status = str(payload.get("status", "")).lower()
+            status = str(self._extract_status(payload)).lower()
             logger.debug(
                 "Runway task status",
                 extra={"task_id": task_id, "status": status, "payload": payload},
@@ -242,11 +242,25 @@ class ImageService:
     def _extract_error(payload: Dict[str, Any]) -> str:
         """Extract a user friendly error message from an API response."""
 
-        candidates = [
-            payload.get("error"),
-            payload.get("message"),
-            payload.get("detail"),
-        ]
+        primary = ImageService._find_first_value(
+            payload,
+            (
+                "message",
+                "detail",
+                "error",
+                "description",
+                "error_description",
+                "error_message",
+                "reason",
+                "title",
+                "msg",
+            ),
+        )
+        text = ImageService._normalise_text(primary)
+        if text:
+            return text
+
+        candidates: list[Any] = []
 
         # برخی پاسخ‌ها شامل ساختار تو در تو هستند
         details = payload.get("errors")
@@ -256,8 +270,147 @@ class ImageService:
             candidates.extend(str(item) for item in details)
 
         for candidate in candidates:
-            text = str(candidate or "").strip()
+            text = ImageService._normalise_text(candidate)
             if text:
                 return text
 
         return "در پردازش درخواست خطایی رخ داد."
+
+    @staticmethod
+    def _normalise_text(value: Any) -> str:
+        if isinstance(value, str):
+            return value.strip()
+        if value is None:
+            return ""
+        return str(value).strip()
+
+    @classmethod
+    def _extract_task_id(cls, payload: Dict[str, Any]) -> str | None:
+        """Try to locate the task identifier in various response layouts."""
+
+        def _from_container(container: Optional[Dict[str, Any]]) -> str | None:
+            if not isinstance(container, dict):
+                return None
+            for key in ("task_id", "id"):
+                raw = container.get(key)
+                text = cls._normalise_text(raw)
+                if not text:
+                    continue
+                if key == "id" and not cls._looks_like_task_id(text, container):
+                    continue
+                return text
+            return None
+
+        if isinstance(payload, dict):
+            containers: list[Any] = [
+                payload,
+                payload.get("data"),
+                payload.get("task"),
+                payload.get("result"),
+            ]
+            for container in containers:
+                if isinstance(container, dict):
+                    found = _from_container(container)
+                    if found:
+                        return found
+                elif isinstance(container, list):
+                    for item in container:
+                        if isinstance(item, dict):
+                            found = _from_container(item)
+                            if found:
+                                return found
+
+        for _key, candidate, _container in cls._iter_values(payload, ("task_id",)):
+            text = cls._normalise_text(candidate)
+            if text:
+                return text
+
+        for _key, candidate, container in cls._iter_values(payload, ("id",)):
+            text = cls._normalise_text(candidate)
+            if text and cls._looks_like_task_id(text, container):
+                return text
+
+        return None
+
+    @classmethod
+    def _extract_status(cls, payload: Dict[str, Any]) -> str:
+        """Return the task status from possibly nested responses."""
+
+        direct = cls._normalise_text(payload.get("status"))
+        if direct:
+            return direct
+
+        nested = cls._find_first_value(payload, ("status",))
+        return cls._normalise_text(nested)
+
+    @staticmethod
+    def _looks_like_task_id(value: str, context: Any) -> bool:
+        lowered = value.lower()
+        if lowered.startswith("task"):
+            return True
+        if isinstance(context, dict) and any(
+            key in context for key in ("status", "state", "task_id")
+        ):
+            return True
+        if isinstance(context, dict):
+            descriptor = context.get("object") or context.get("type")
+            if isinstance(descriptor, str) and "task" in descriptor.lower():
+                return True
+        return False
+
+    @classmethod
+    def _find_first_value(
+        cls, data: Any, keys: tuple[str, ...], _visited: Optional[set[int]] = None
+    ) -> Any | None:
+        if _visited is None:
+            _visited = set()
+
+        obj_id = id(data)
+        if obj_id in _visited:
+            return None
+        _visited.add(obj_id)
+
+        if isinstance(data, dict):
+            for key in keys:
+                if key in data:
+                    value = data[key]
+                    nested = cls._find_first_value(value, keys, _visited)
+                    if nested is not None:
+                        return nested
+                    text = cls._normalise_text(value)
+                    if text:
+                        return value
+            for value in data.values():
+                result = cls._find_first_value(value, keys, _visited)
+                if result is not None:
+                    return result
+
+        elif isinstance(data, (list, tuple, set)):
+            for item in data:
+                result = cls._find_first_value(item, keys, _visited)
+                if result is not None:
+                    return result
+
+        return None
+
+    @classmethod
+    def _iter_values(
+        cls, data: Any, keys: tuple[str, ...], _visited: Optional[set[int]] = None
+    ) -> Iterable[tuple[str, Any, Dict[str, Any]]]:
+        if _visited is None:
+            _visited = set()
+
+        obj_id = id(data)
+        if obj_id in _visited:
+            return
+        _visited.add(obj_id)
+
+        if isinstance(data, dict):
+            for key, value in data.items():
+                if key in keys:
+                    yield (key, value, data)
+                yield from cls._iter_values(value, keys, _visited)
+
+        elif isinstance(data, (list, tuple, set)):
+            for item in data:
+                yield from cls._iter_values(item, keys, _visited)

--- a/tests/test_image_service.py
+++ b/tests/test_image_service.py
@@ -1,0 +1,113 @@
+"""Tests for the Runway image service helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from modules.image.service import ImageGenerationError, ImageService
+
+
+class DummyResponse:
+    """Simple stand-in for ``requests.Response`` used in the tests."""
+
+    def __init__(self, payload: Dict[str, Any], status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self) -> Dict[str, Any]:  # noqa: D401 - mimics ``requests.Response``
+        """Return the JSON payload."""
+
+        return self._payload
+
+
+@pytest.fixture(autouse=True)
+def _runway_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure the service sees a Runway token during the tests."""
+
+    monkeypatch.setenv("RUNWAY_API", "test-token")
+
+
+def test_generate_image_accepts_wrapped_task_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = ImageService()
+
+    def fake_request(self: ImageService, method: str, path: str, **_: Any) -> DummyResponse:  # noqa: ANN001
+        assert method == "POST" and path == "/tasks"
+        return DummyResponse({"data": {"id": "task-xyz", "status": "queued"}})
+
+    monkeypatch.setattr(ImageService, "_request", fake_request)
+
+    task_id = service.generate_image("a friendly robot")
+    assert task_id == "task-xyz"
+
+
+def test_generate_image_ignores_unrelated_ids(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = ImageService()
+
+    payload = {
+        "user": {"id": "user-123"},
+        "data": {
+            "items": [
+                {"id": "asset-789"},
+                {"task": {"id": "runway-task-456", "status": "queued"}},
+            ]
+        },
+    }
+
+    def fake_request(self: ImageService, method: str, path: str, **_: Any) -> DummyResponse:  # noqa: ANN001
+        assert method == "POST" and path == "/tasks"
+        return DummyResponse(payload)
+
+    monkeypatch.setattr(ImageService, "_request", fake_request)
+
+    task_id = service.generate_image("find the correct id")
+    assert task_id == "runway-task-456"
+
+
+def test_get_image_status_handles_nested_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = ImageService()
+
+    poll_payloads = [
+        {"data": {"status": "pending"}},
+        {"task": {"status": "SUCCEEDED"}},
+    ]
+
+    def fake_request(self: ImageService, method: str, path: str, **_: Any) -> DummyResponse:  # noqa: ANN001
+        if method == "GET" and path == "/tasks/task-xyz":
+            if not poll_payloads:
+                raise AssertionError("No more poll payloads available")
+            return DummyResponse(poll_payloads.pop(0))
+        if method == "GET" and path == "/tasks/task-xyz/assets":
+            return DummyResponse({"items": [{"url": "https://example.com/image.png"}]})
+        raise AssertionError(f"Unexpected request: {method} {path}")
+
+    monkeypatch.setattr(ImageService, "_request", fake_request)
+    monkeypatch.setattr("modules.image.service.time.sleep", lambda _: None)
+
+    result = service.get_image_status("task-xyz", poll_interval=0, timeout=5)
+
+    assert result.get("assets")
+    assert not poll_payloads
+
+
+def test_extract_task_id_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure a helpful error is raised when no ID is present."""
+
+    service = ImageService()
+
+    def fake_request(self: ImageService, method: str, path: str, **_: Any) -> DummyResponse:  # noqa: ANN001
+        if method == "POST" and path == "/tasks":
+            return DummyResponse({"data": {"assets": []}})
+        raise AssertionError(f"Unexpected request: {method} {path}")
+
+    monkeypatch.setattr(ImageService, "_request", fake_request)
+
+    with pytest.raises(ImageGenerationError):
+        service.generate_image("missing id response")


### PR DESCRIPTION
## Summary
- handle nested Runway API responses when extracting task IDs and statuses while skipping unrelated identifiers
- improve error message handling and add helpers for parsing Runway payloads
- add unit tests covering wrapped responses, identifier prioritisation, and failure scenarios for image generation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1550f230883328993ac563b8dfcd7