### PR TITLE
Remove image generation button from main menu

### DIFF
--- a/modules/home/keyboards.py
+++ b/modules/home/keyboards.py
@@ -12,9 +12,6 @@ def main_menu(lang: str) -> InlineKeyboardMarkup:
     )
     kb.row(
         InlineKeyboardButton(t("btn_tts", lang), callback_data="home:tts"),
-    )
-    kb.row(
-        InlineKeyboardButton(t("btn_image", lang), callback_data="home:image"),
         InlineKeyboardButton(t("btn_gpt", lang), callback_data="home:gpt_chat"),
     )
     kb.row(


### PR DESCRIPTION
## Summary
- remove the image generation entry from the home main menu keyboard
- keep the GPT chat button paired with the TTS button to maintain layout consistency

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d43f663ee8833290f21da7a737a8b6