### PR TITLE
Fix missing imghdr import crash in image service

### DIFF
--- a/modules/image/_compat.py
+++ b/modules/image/_compat.py
@@ -1,0 +1,30 @@
+"""Compatibility helpers for the image module.
+
+This module currently provides a safe way to import :mod:`imghdr` while also
+registering a backwards-compatible alias for the common ``imgdhr`` typo that
+appears in some deployments.  When the alias is present, environments still
+running the buggy import line will transparently receive the standard library
+module instead of crashing with ``ModuleNotFoundError``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from types import ModuleType
+
+
+def _load_imghdr() -> ModuleType:
+    """Return the :mod:`imghdr` module and register an alias for ``imgdhr``."""
+
+    module = importlib.import_module("imghdr")
+    # Some historical deployments imported ``imgdhr`` by mistake.  Making the
+    # alias available keeps those environments working while we roll out the fix
+    # everywhere else.
+    sys.modules.setdefault("imgdhr", module)
+    return module
+
+
+imghdr = _load_imghdr()
+
+__all__ = ["imghdr"]

--- a/modules/image/service.py
+++ b/modules/image/service.py
@@ -17,7 +17,6 @@ hold the Runway API token.
 from __future__ import annotations
 
 import base64
-import imghdr
 import logging
 import os
 import time
@@ -26,6 +25,7 @@ from typing import Any, Dict, Optional
 import requests
 import mimetypes
 
+from ._compat import imghdr
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- add a compatibility helper that exposes the stdlib `imghdr` module under the historic `imgdhr` typo
- update the Runway image service to import `imghdr` through the compatibility layer so old deployments stop crashing

## Testing
- python -m compileall modules/image

------
https://chatgpt.com/codex/tasks/task_e_68d93f40a2e883328edfb48afa1dc362