### PR TITLE
Adjust service credit pricing

### DIFF
--- a/config.py
+++ b/config.py
@@ -100,8 +100,8 @@ GPT_HISTORY_LIMIT = max(1, _parse_int(os.getenv("GPT_HISTORY_LIMIT", "6"), 6))
 GPT_TEMPERATURE = min(2.0, max(0.0, _parse_float(os.getenv("GPT_TEMPERATURE"), 0.7)))
 GPT_TOP_P = min(1.0, max(0.0, _parse_float(os.getenv("GPT_TOP_P"), 1.0)))
 GPT_MAX_TOKENS = max(0, _parse_int(os.getenv("GPT_MAX_TOKENS"), 400))
-GPT_MESSAGE_COST = _parse_float(os.getenv("GPT_MESSAGE_COST", "1"), 1.0)
-GPT_SEARCH_MESSAGE_COST = _parse_float(os.getenv("GPT_SEARCH_MESSAGE_COST", "2"), 2.0)
+GPT_MESSAGE_COST = _parse_float(os.getenv("GPT_MESSAGE_COST", "0.1"), 0.1)
+GPT_SEARCH_MESSAGE_COST = _parse_float(os.getenv("GPT_SEARCH_MESSAGE_COST", "0.1"), 0.1)
 
 GPT_RESPONSE_CHAR_LIMIT = max(
     0,

--- a/modules/clone/settings.py
+++ b/modules/clone/settings.py
@@ -2,7 +2,7 @@
 
 STATE_WAIT_VOICE = "clone:wait_voice"
 STATE_WAIT_PAYMENT = "clone:wait_payment"
-STATE_WAIT_NAME  = "clone:wait_name"
+STATE_WAIT_NAME = "clone:wait_name"
 
 # هزینه ساخت صدای شخصی
-VOICE_CLONE_COST = 6800
+VOICE_CLONE_COST = 200

--- a/modules/clone/texts.py
+++ b/modules/clone/texts.py
@@ -6,11 +6,11 @@ def MENU(lang: str = "fa") -> str:
     return t("clone_menu", lang)
 
 
-def PAYMENT_CONFIRM(lang: str = "fa", cost: int = 6800) -> str:
+def PAYMENT_CONFIRM(lang: str = "fa", cost: int = 200) -> str:
     return t("clone_payment_confirm", lang).format(cost=cost)
 
 
-def NO_CREDIT_CLONE(lang: str = "fa", balance: int = 0, cost: int = 6800) -> str:
+def NO_CREDIT_CLONE(lang: str = "fa", balance: int = 0, cost: int = 200) -> str:
     return t("clone_insufficient_credit", lang).format(balance=balance, cost=cost)
 
 

--- a/modules/image/settings.py
+++ b/modules/image/settings.py
@@ -2,6 +2,6 @@
 
 STATE_WAIT_PROMPT = "image:wait_prompt"
 STATE_PROCESSING = "image:processing"
-CREDIT_COST = 72
+CREDIT_COST = 5
 POLL_INTERVAL = 3.0
 POLL_TIMEOUT = 300

--- a/modules/tts/handlers.py
+++ b/modules/tts/handlers.py
@@ -189,10 +189,10 @@ def register(bot):
             except Exception:
                 pass
 
-            # محاسبه هزینه: صداهای کاستوم ۲ کردیت، بقیه ۱ کردیت
+            # محاسبه هزینه: صداهای کاستوم دو برابر هزینه پایه دارند
             is_custom_voice = db.get_user_voice(user_id, voice_name) is not None
-            cost_per_char = 2 if is_custom_voice else CREDIT_PER_CHAR
-            cost = len(text) * cost_per_char
+            multiplier = 2 if is_custom_voice else 1
+            cost = round(len(text) * CREDIT_PER_CHAR * multiplier, 2)
             if user["credits"] < cost:
                 # state رو پاک نکن تا بتونیم منوی TTS رو بعداً پاک کنیم
                 from .keyboards import no_credit_keyboard

--- a/modules/tts/settings.py
+++ b/modules/tts/settings.py
@@ -3,8 +3,8 @@
 # نام State برای انتظار متن
 STATE_WAIT_TEXT = "tts:wait_text"
 
-# هر کاراکتر = 1 کردیت
-CREDIT_PER_CHAR = 1
+# هر کاراکتر = 0.05 کردیت
+CREDIT_PER_CHAR = 0.05
 
 # صدای پیش‌فرض (وقتی هنوز چیزی ذخیره نشده)
 DEFAULT_VOICE_NAME = "Nazy"


### PR DESCRIPTION
## Summary
- update the default GPT message credit cost to 0.1
- lower TTS per-character pricing and keep custom voices at twice the base rate
- align image generation and voice cloning credit costs with the new pricing model

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9631fea548332b6ae5c5f03d84748