### PR TITLE
Add admin bulk credit formula tool

### DIFF
--- a/db.py
+++ b/db.py
@@ -354,6 +354,23 @@ def get_all_user_ids():
         cur.execute("SELECT user_id FROM users")
         return [r[0] for r in cur.fetchall()]
 
+def get_all_user_credits():
+    with closing(sqlite3.connect(DB_PATH)) as con:
+        cur = con.cursor()
+        cur.execute("SELECT user_id, credits FROM users ORDER BY user_id ASC")
+        return cur.fetchall()
+
+def bulk_update_user_credits(updates):
+    """updates should be iterable of (new_credits, user_id). Returns number of affected rows."""
+    updates = list(updates)
+    if not updates:
+        return 0
+    with closing(sqlite3.connect(DB_PATH)) as con:
+        cur = con.cursor()
+        cur.executemany("UPDATE users SET credits=? WHERE user_id=?", updates)
+        con.commit()
+        return len(updates)
+
 def export_user_messages_csv(user_id: int, path=None):
     if path is None:
         path = f"user_{user_id}_messages.csv"

--- a/modules/admin/keyboards.py
+++ b/modules/admin/keyboards.py
@@ -13,6 +13,7 @@ def admin_menu():
         InlineKeyboardButton("➕ افزودن کردیت", callback_data="admin:add"),
         InlineKeyboardButton("➖ کسر کردیت", callback_data="admin:sub"),
     )
+    kb.add(InlineKeyboardButton("🧮 فرمول کردیت همگانی", callback_data="admin:bulk_credit"))
     kb.add(InlineKeyboardButton("♻️ ریست کاربر", callback_data="admin:reset"))
     kb.row(
         InlineKeyboardButton("✉️ پیام تکی", callback_data="admin:dm"),

--- a/modules/admin/texts.py
+++ b/modules/admin/texts.py
@@ -42,6 +42,13 @@ STATE_MSG_TXT = "ADMIN:DM:TXT"
 ASK_TXT_CAST  = "📣 متن پیام همگانی را بفرستید."
 STATE_CAST_TXT = "ADMIN:CAST:TXT"
 
+# ——— به‌روزرسانی همگانی کردیت با فرمول
+ASK_FORMULA     = (
+    "🧮 فرمول محاسبه کردیت جدید را بفرستید.\n"
+    "می‌توانید از متغیر <code>old</code> (کردیت فعلی) استفاده کنید، مثلا: <code>old * 0.045</code>."
+)
+STATE_FORMULA   = "ADMIN:CREDITS:FORMULA"
+
 # ——— تنظیمات: بونوس رفرال
 ASK_BONUS      = "🎁 مقدار بونوس رفرال را بفرستید (عدد)."
 STATE_SET_BONUS = "ADMIN:SET:BONUS"


### PR DESCRIPTION
## Summary
- remove the standalone script for recalculating credits
- add an admin panel action that accepts a formula and updates every user's credits with rounding
- provide safe formula evaluation, preview output, and bulk database update helpers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d97e8f7f98833292915bc7c2c0fdfe