### PR TITLE
Add admin image export and logging

### DIFF
--- a/modules/admin/keyboards.py
+++ b/modules/admin/keyboards.py
@@ -93,6 +93,12 @@ def user_actions(uid: int):
         InlineKeyboardButton("📥 متن‌های TTS کاربر", callback_data=f"admin:exp_user_tts:{uid}"),
         InlineKeyboardButton("💬 پیام‌های کاربر",     callback_data=f"admin:exp_user_msgs:{uid}"),
     )
+    kb.add(
+        InlineKeyboardButton(
+            "🖼️ دانلود تبدیل عکس‌های کاربر",
+            callback_data=f"admin:exp_user_images:{uid}"
+        )
+    )
     kb.add(InlineKeyboardButton("⬅️ بازگشت", callback_data="admin:users"))
     return kb
 

--- a/modules/image/handlers.py
+++ b/modules/image/handlers.py
@@ -216,6 +216,10 @@ def _process_prompt(bot: TeleBot, message: Message, user, prompt: str, lang: str
             reply_to_message_id=message.message_id,
             parse_mode="HTML",
         )
+        try:
+            db.log_image_generation(user["user_id"], prompt, image_url)
+        except Exception:
+            logger.exception("Failed to log image generation for user %s", user["user_id"])
         db.deduct_credits(user["user_id"], CREDIT_COST)
 
         try:


### PR DESCRIPTION
## Summary
- store every generated image in a dedicated `image_generations` table and expose helper utilities
- log image generations from the image module and count users with image activity in admin statistics
- add an admin action to download a ZIP archive of a user's generated images and expose it in the UI

## Testing
- python -m compileall db.py modules/admin/handlers.py modules/admin/keyboards.py modules/image/handlers.py

------
https://chatgpt.com/codex/tasks/task_e_68d9a9b0db6c83329bf59291acc2deef