### PR TITLE
Fix image download fallback for bots missing download_file_by_id

### DIFF
--- a/modules/image/handlers.py
+++ b/modules/image/handlers.py
@@ -141,8 +141,6 @@ def _download_file(bot: TeleBot, file_id: str) -> tuple[bytes, str | None]:
                 content = download_by_id(file_id)
             except Exception:
                 content = None
-        # generates a temporary path without an extension.
-        content = bot.download_file_by_id(file_id)
 
     if not content:
         raise RuntimeError("empty file content")


### PR DESCRIPTION
## Summary
- avoid calling download_file_by_id when the TeleBot client does not expose the helper
- keep the image download flow from crashing on bots that rely on the primary file path download

## Testing
- python -m compileall modules/image/handlers.py

------
https://chatgpt.com/codex/tasks/task_e_68d9bc0d967083329d43cf45245624cb