### PR TITLE
Add language-based user statistics to admin panel

### DIFF
--- a/db.py
+++ b/db.py
@@ -351,6 +351,22 @@ def count_users_with_images() -> int:
         return result[0] if result else 0
 
 
+def count_users_by_lang():
+    with closing(sqlite3.connect(DB_PATH)) as con:
+        cur = con.cursor()
+        cur.execute(
+            """
+            SELECT COALESCE(NULLIF(lang, ''), 'fa') AS lang,
+                   COUNT(*) AS total
+              FROM users
+          GROUP BY COALESCE(NULLIF(lang, ''), 'fa')
+          ORDER BY total DESC
+            """
+        )
+        rows = cur.fetchall() or []
+    return [(row[0], row[1]) for row in rows]
+
+
 def _guess_image_extension(url: str, content_type: str | None) -> str:
     parsed = urlparse(url or "")
     candidate = os.path.splitext(parsed.path)[1]

--- a/modules/admin/handlers.py
+++ b/modules/admin/handlers.py
@@ -30,6 +30,9 @@ from .keyboards import (
     exports_menu,
     image_users_menu,
 )
+from modules.lang.keyboards import LANGS
+
+LANG_LABELS = {code: label for label, code in LANGS}
 
 # ---------- Helpers ----------
 def _is_owner(u) -> bool:
@@ -257,6 +260,30 @@ def register(bot):
                 edit_or_send(bot, cq.message.chat.id, cq.message.message_id, "👥 لیست کاربران:", users_menu(page))
             else:
                 edit_or_send(bot, cq.message.chat.id, cq.message.message_id, "👥 لیست کاربران:", users_menu())
+            return
+
+        if action == "lang_users":
+            stats = db.count_users_by_lang()
+            total = sum(count for _, count in stats)
+            lines = ["🌐 <b>کاربران بر اساس زبان</b>", ""]
+
+            if not total:
+                lines.append("هنوز کاربری ثبت نشده است.")
+            else:
+                for code, count in stats:
+                    label = LANG_LABELS.get(code)
+                    if not label:
+                        label = code or "نامشخص"
+                    if code not in LANG_LABELS and code:
+                        label = f"{label} ({code})"
+                    if total:
+                        percent = (count / total) * 100
+                        lines.append(f"• {label}: <b>{count}</b> ({percent:.1f}٪)")
+                    else:
+                        lines.append(f"• {label}: <b>{count}</b>")
+
+            txt = "\n".join(lines)
+            edit_or_send(bot, cq.message.chat.id, cq.message.message_id, txt, admin_menu())
             return
 
         # لیست کاربران تولید تصویر

--- a/modules/admin/keyboards.py
+++ b/modules/admin/keyboards.py
@@ -12,6 +12,9 @@ def admin_menu():
         InlineKeyboardButton("👥 کاربران", callback_data="admin:users"),
     )
     kb.row(
+        InlineKeyboardButton("🌐 کاربران بر اساس زبان", callback_data="admin:lang_users"),
+    )
+    kb.row(
         InlineKeyboardButton("🖼️ کاربران تصویر", callback_data="admin:image_users"),
     )
     kb.row(


### PR DESCRIPTION
## Summary
- add an admin menu entry to show user counts by language
- aggregate users by their selected bot language and present formatted stats

## Testing
- python -m compileall modules/admin db.py

------
https://chatgpt.com/codex/tasks/task_e_68dad25145bc8332a588eed21955f6bd