### PR TITLE
Remove API Token option from main menu

### DIFF
--- a/modules/home/keyboards.py
+++ b/modules/home/keyboards.py
@@ -18,9 +18,6 @@ def main_menu(lang: str) -> InlineKeyboardMarkup:
         InlineKeyboardButton(t("btn_gpt", lang), callback_data="home:gpt_chat"),
     )
     kb.row(
-        InlineKeyboardButton(t("btn_api_token", lang), callback_data="home:api_token"),
-    )
-    kb.row(
         InlineKeyboardButton(t("btn_lang", lang), callback_data="home:lang"),
         InlineKeyboardButton(t("btn_invite", lang), callback_data="home:invite"),
     )


### PR DESCRIPTION
## Summary
- remove the API Token button from the home main menu keyboard

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daea6a4d388332938b76c59bbb75a1