### PR TITLE
Update Persian image caption with Vexa.ai link

### DIFF
--- a/modules/i18n.py
+++ b/modules/i18n.py
@@ -207,7 +207,7 @@ LABELS = {
         "fr": "⚠️ Le service de génération d'images n'est pas configuré. Réessaie plus tard.",
     },
     "image_result_caption": {
-        "fa": "🎉 تصویر آماده شد! {cost} کردیت از حسابت کم شد.",
+        "fa": "<b>تصویر آمـاده شد 🫟 <a href=\"https://t.me/AIvexaBOT\">Vexa.ai</a></b>",
         "en": "🎉 Image ready! {cost} credits were deducted.",
         "ar": "🎉 الصورة جاهزة! تم خصم {cost} رصيداً.",
         "tr": "🎉 Görsel hazır! {cost} kredi düşüldü.",


### PR DESCRIPTION
## Summary
- update the Persian image result caption to bold text and link Vexa.ai in the output message

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db94e9518083329591b6c6f28d8d31