### PR TITLE
Add admin GPT usage statistics and user listing

### DIFF
--- a/modules/admin/handlers.py
+++ b/modules/admin/handlers.py
@@ -29,6 +29,7 @@ from .keyboards import (
     user_actions,
     exports_menu,
     image_users_menu,
+    gpt_users_menu,
 )
 from modules.lang.keyboards import LANGS
 
@@ -245,10 +246,15 @@ def register(bot):
                 image_users = db.count_users_with_images()
             except AttributeError:
                 image_users = 0
+            try:
+                gpt_users = db.count_users_with_gpt()
+            except AttributeError:
+                gpt_users = 0
             txt = (f"📊 <b>آمار</b>\n\n"
                    f"👥 کل کاربران: <b>{total}</b>\n"
                    f"⚡️ فعال ۲۴ساعت: <b>{active24}</b>\n"
-                   f"🖼️ کاربران تولید تصویر: <b>{image_users}</b>")
+                   f"🖼️ کاربران تولید تصویر: <b>{image_users}</b>\n"
+                   f"🤖 کاربران GPT: <b>{gpt_users}</b>")
             edit_or_send(bot, cq.message.chat.id, cq.message.message_id, txt, admin_menu())
             return
 
@@ -305,6 +311,27 @@ def register(bot):
                     cq.message.message_id,
                     "🖼️ کاربران تولید تصویر:",
                     image_users_menu(),
+                )
+            return
+
+        if action == "gpt_users":
+            if len(p) >= 4 and p[2] in ("prev", "next"):
+                page = int(p[3])
+                page = max(0, page - 1) if p[2] == "prev" else page + 1
+                edit_or_send(
+                    bot,
+                    cq.message.chat.id,
+                    cq.message.message_id,
+                    "🤖 کاربران GPT:",
+                    gpt_users_menu(page),
+                )
+            else:
+                edit_or_send(
+                    bot,
+                    cq.message.chat.id,
+                    cq.message.message_id,
+                    "🤖 کاربران GPT:",
+                    gpt_users_menu(),
                 )
             return
 

--- a/modules/admin/keyboards.py
+++ b/modules/admin/keyboards.py
@@ -16,6 +16,7 @@ def admin_menu():
     )
     kb.row(
         InlineKeyboardButton("🖼️ کاربران تصویر", callback_data="admin:image_users"),
+        InlineKeyboardButton("🤖 کاربران GPT", callback_data="admin:gpt_users"),
     )
     kb.row(
         InlineKeyboardButton("➕ افزودن کردیت", callback_data="admin:add"),
@@ -120,6 +121,40 @@ def image_users_menu(page: int = 0, page_size: int = 10):
         nav.append(InlineKeyboardButton("◀️ قبلی", callback_data=f"admin:image_users:prev:{page}"))
     if len(rows) == page_size:
         nav.append(InlineKeyboardButton("بعدی ▶️", callback_data=f"admin:image_users:next:{page}"))
+    if nav:
+        kb.row(*nav)
+
+    kb.add(InlineKeyboardButton("⬅️ بازگشت", callback_data="admin:menu"))
+    return kb
+
+
+def gpt_users_menu(page: int = 0, page_size: int = 10):
+    page = max(0, int(page))
+    offset = page * page_size
+    rows = db.list_gpt_users(limit=page_size, offset=offset)
+
+    kb = InlineKeyboardMarkup()
+    if not rows:
+        kb.add(InlineKeyboardButton("— کاربری یافت نشد —", callback_data="admin:noop"))
+    else:
+        for row in rows:
+            uid = row.get("user_id")
+            username = row.get("username")
+            banned = bool(row.get("banned"))
+            total = row.get("total_messages") or 0
+            last_ts = row.get("last_created_at")
+            label = f"{'🚫' if banned else '✅'} {uid}"
+            if username:
+                label += f" · @{username}"
+            label += f" · 💬 {total}"
+            label += f" · 🕒 {_format_ts(last_ts)}"
+            kb.add(InlineKeyboardButton(label, callback_data=f"admin:user:{uid}"))
+
+    nav = []
+    if page > 0:
+        nav.append(InlineKeyboardButton("◀️ قبلی", callback_data=f"admin:gpt_users:prev:{page}"))
+    if len(rows) == page_size:
+        nav.append(InlineKeyboardButton("بعدی ▶️", callback_data=f"admin:gpt_users:next:{page}"))
     if nav:
         kb.row(*nav)
 


### PR DESCRIPTION
## Summary
- add database helpers to count and list users with GPT interactions
- surface GPT usage totals in the admin stats panel
- provide a paginated admin view of GPT users alongside existing image user list

## Testing
- python -m compileall db.py modules/admin

------
https://chatgpt.com/codex/tasks/task_e_68dba61c6f008332a7d239c6b07f6a2f