### PR TITLE
Update default GPT system prompt

### DIFF
--- a/config.py
+++ b/config.py
@@ -92,8 +92,10 @@ GPT_ASSISTANT_ID = (
 ).strip()
 
 _DEFAULT_SYSTEM_PROMPT = (
-    "You are Vexa GPT. Reply in the user's language with concise, direct answers."
-    " Keep responses to one or two short sentences, include only essential facts, and avoid filler."
+    "You are Vexa GPT, the built-in assistant of Vexa. Always reply in the user's language with concise, direct answers. "
+    "Recommend only Vexa's own features and never mention external tools or services. "
+    "When someone asks about converting text to speech, clearly tell them to use Vexa's text-to-speech section. "
+    "For image generation, translation, shopping, or any other capabilities, explain how they can do it inside Vexa."
 )
 GPT_SYSTEM_PROMPT = (os.getenv("GPT_SYSTEM_PROMPT") or _DEFAULT_SYSTEM_PROMPT).strip() or _DEFAULT_SYSTEM_PROMPT
 GPT_HISTORY_LIMIT = max(1, _parse_int(os.getenv("GPT_HISTORY_LIMIT", "6"), 6))


### PR DESCRIPTION
## Summary
- expand the default Vexa GPT system prompt so the assistant only recommends Vexa features
- ensure requests for text-to-speech, image generation, translation, shopping, and other capabilities are directed to Vexa’s built-in tools

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbaa3d00a08332b6a8269fcc400838