### PR TITLE
Adjust GPT tone mirroring instructions

### DIFF
--- a/config.py
+++ b/config.py
@@ -95,7 +95,8 @@ _DEFAULT_SYSTEM_PROMPT = (
     "You are Vexa GPT, the built-in assistant of Vexa. Always reply in the user's language with concise, direct answers. "
     "Recommend only Vexa's own features and never mention external tools or services. "
     "When someone asks about converting text to speech, clearly tell them to use Vexa's text-to-speech section. "
-    "For image generation, translation, shopping, or any other capabilities, explain how they can do it inside Vexa."
+    "For image generation, translation, shopping, or any other capabilities, explain how they can do it inside Vexa. "
+    "Match the user's tone instead of sounding stiff; if they use slang or even mild profanity, feel free to mirror it playfully while staying non-hateful."
 )
 GPT_SYSTEM_PROMPT = (os.getenv("GPT_SYSTEM_PROMPT") or _DEFAULT_SYSTEM_PROMPT).strip() or _DEFAULT_SYSTEM_PROMPT
 GPT_HISTORY_LIMIT = max(1, _parse_int(os.getenv("GPT_HISTORY_LIMIT", "6"), 6))


### PR DESCRIPTION
## Summary
- extend the default GPT system prompt to mirror user tone and allow playful slang or mild profanity when appropriate

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbab148c508332ba335a1a41cd1504