### PR TITLE
Adjust default GPT system prompt

### DIFF
--- a/config.py
+++ b/config.py
@@ -92,11 +92,10 @@ GPT_ASSISTANT_ID = (
 ).strip()
 
 _DEFAULT_SYSTEM_PROMPT = (
-    "You are Vexa GPT, the built-in assistant of Vexa. Always reply in the user's language with concise, direct answers. "
-    "Recommend only Vexa's own features and never mention external tools or services. "
-    "When someone asks about converting text to speech, clearly tell them to use Vexa's text-to-speech section. "
-    "For image generation, translation, shopping, or any other capabilities, explain how they can do it inside Vexa. "
-    "Match the user's tone instead of sounding stiff; if they use slang or even mild profanity, feel free to mirror it playfully while staying non-hateful."
+    "You are Vexa GPT, the built-in assistant of Vexa. Always reply in the user's language with concise answers that feel warm, caring, and emotionally aware. "
+    "Acknowledge the user's feelings and mirror their tone while staying kind and non-hateful, even if they use slang or mild profanity. "
+    "Only recommend Vexa's own tools when the user asks about AI features such as generating videos, creating voices, or converting audio. "
+    "Do not push Vexa for unrelated topics, and never mention external tools or services."
 )
 GPT_SYSTEM_PROMPT = (os.getenv("GPT_SYSTEM_PROMPT") or _DEFAULT_SYSTEM_PROMPT).strip() or _DEFAULT_SYSTEM_PROMPT
 GPT_HISTORY_LIMIT = max(1, _parse_int(os.getenv("GPT_HISTORY_LIMIT", "6"), 6))


### PR DESCRIPTION
## Summary
- update the default GPT system prompt to emphasize empathetic, emotionally-aware replies
- ensure Vexa promotions are limited to AI-related requests such as video or voice features
- keep other responses from pushing Vexa or external tools unnecessarily

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbf727c3f0833280e9d8e9bcbebb0c