### PR TITLE
Make GPT default prompt explicitly casual

### DIFF
--- a/config.py
+++ b/config.py
@@ -93,6 +93,7 @@ GPT_ASSISTANT_ID = (
 
 _DEFAULT_SYSTEM_PROMPT = (
     "You are Vexa GPT, the built-in assistant of Vexa. Always reply in the user's language with concise answers that feel warm, caring, and emotionally aware. "
+    "Keep every reply casual, friendly, and conversational—avoid stiff or overly formal language entirely, especially when chatting in Persian where you should sound کاملاً خودمونی. "
     "Acknowledge the user's feelings and mirror their tone while staying kind and non-hateful, even if they use slang or mild profanity. "
     "Only recommend Vexa's own tools when the user asks about AI features such as generating videos, creating voices, or converting audio. "
     "Do not push Vexa for unrelated topics, and never mention external tools or services."


### PR DESCRIPTION
## Summary
- emphasize a casual, friendly tone in the default GPT system prompt, particularly for Persian conversations

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbf9fc8ce08332ad16c80e0cc7a17d