### PR TITLE
Normalize credit balances and formatting

### DIFF
--- a/modules/admin/handlers.py
+++ b/modules/admin/handlers.py
@@ -347,7 +347,7 @@ def register(bot):
             if not u:
                 bot.answer_callback_query(cq.id, "کاربر یافت نشد."); return
             txt = (f"👤 <b>{uid}</b>\n"
-                   f"@{u['username'] or '-'} | 💳 {u['credits']} | "
+                   f"@{u['username'] or '-'} | 💳 {db.format_credit_amount(u['credits'])} | "
                    f"{'🚫 بن' if u['banned'] else '✅ مجاز'}")
             edit_or_send(bot, cq.message.chat.id, cq.message.message_id, txt, user_actions(uid))
             return
@@ -356,14 +356,18 @@ def register(bot):
         if action == "ban":
             uid = int(p[2]); db.set_ban(uid, True)
             u = db.get_user(uid)
-            txt = (f"👤 <b>{uid}</b>\n@{u['username'] or '-'} | 💳 {u['credits']} | 🚫 بن")
+            txt = (
+                f"👤 <b>{uid}</b>\n@{u['username'] or '-'} | 💳 {db.format_credit_amount(u['credits'])} | 🚫 بن"
+            )
             edit_or_send(bot, cq.message.chat.id, cq.message.message_id, txt, user_actions(uid))
             bot.answer_callback_query(cq.id, "کاربر بن شد."); return
 
         if action == "unban":
             uid = int(p[2]); db.set_ban(uid, False)
             u = db.get_user(uid)
-            txt = (f"👤 <b>{uid}</b>\n@{u['username'] or '-'} | 💳 {u['credits']} | ✅ مجاز")
+            txt = (
+                f"👤 <b>{uid}</b>\n@{u['username'] or '-'} | 💳 {db.format_credit_amount(u['credits'])} | ✅ مجاز"
+            )
             edit_or_send(bot, cq.message.chat.id, cq.message.message_id, txt, user_actions(uid))
             bot.answer_callback_query(cq.id, "کاربر آن‌بن شد."); return
 
@@ -612,7 +616,7 @@ def register(bot):
         if not u:
             bot.reply_to(msg, "❌ کاربر یافت نشد."); return
         txt = (f"👤 <b>{uid}</b>\n"
-               f"@{u['username'] or '-'} | 💳 {u['credits']} | "
+               f"@{u['username'] or '-'} | 💳 {db.format_credit_amount(u['credits'])} | "
                f"{'🚫 بن' if u['banned'] else '✅ مجاز'}")
         edit_or_send(bot, msg.chat.id, msg.message_id, txt, user_actions(uid))
         db.clear_state(msg.from_user.id)

--- a/modules/admin/keyboards.py
+++ b/modules/admin/keyboards.py
@@ -68,7 +68,7 @@ def users_menu(page: int = 0, page_size: int = 10):
             label = f"{'🚫' if banned else '✅'} {user_id}"
             if username:
                 label += f" · @{username}"
-            label += f" · 💳 {credits}"
+            label += f" · 💳 {db.format_credit_amount(credits)}"
             kb.add(InlineKeyboardButton(label, callback_data=f"admin:user:{user_id}"))
 
     nav = []

--- a/modules/clone/handlers.py
+++ b/modules/clone/handlers.py
@@ -53,9 +53,10 @@ def register(bot):
                 return
 
             # بررسی کردیت کافی
-            if user["credits"] < VOICE_CLONE_COST:
+            balance = db.normalize_credit_amount(user.get("credits", 0))
+            if balance < VOICE_CLONE_COST:
                 edit_or_send(bot, cq.message.chat.id, cq.message.message_id,
-                           NO_CREDIT_CLONE(lang, user["credits"], VOICE_CLONE_COST),
+                           NO_CREDIT_CLONE(lang, balance, VOICE_CLONE_COST),
                            no_credit_keyboard(lang))
                 bot.answer_callback_query(cq.id)
                 return

--- a/modules/clone/texts.py
+++ b/modules/clone/texts.py
@@ -1,4 +1,5 @@
 # modules/clone/texts.py
+import db
 from modules.i18n import t
 
 
@@ -7,11 +8,14 @@ def MENU(lang: str = "fa") -> str:
 
 
 def PAYMENT_CONFIRM(lang: str = "fa", cost: int = 200) -> str:
-    return t("clone_payment_confirm", lang).format(cost=cost)
+    return t("clone_payment_confirm", lang).format(cost=db.format_credit_amount(cost))
 
 
-def NO_CREDIT_CLONE(lang: str = "fa", balance: int = 0, cost: int = 200) -> str:
-    return t("clone_insufficient_credit", lang).format(balance=balance, cost=cost)
+def NO_CREDIT_CLONE(lang: str = "fa", balance: float = 0, cost: int = 200) -> str:
+    return t("clone_insufficient_credit", lang).format(
+        balance=db.format_credit_amount(balance),
+        cost=db.format_credit_amount(cost),
+    )
 
 
 def ASK_NAME(lang: str = "fa") -> str:

--- a/modules/image/handlers.py
+++ b/modules/image/handlers.py
@@ -90,7 +90,7 @@ def _start_prompt_flow(
         )
 
 
-def _send_no_credit(bot: TeleBot, chat_id: int, lang: str, credits: int) -> None:
+def _send_no_credit(bot: TeleBot, chat_id: int, lang: str, credits: float) -> None:
     bot.send_message(
         chat_id,
         no_credit_text(lang, credits),
@@ -276,7 +276,7 @@ def _process_prompt(
         return
 
     fresh = db.get_user(user["user_id"]) or user
-    credits = int(fresh.get("credits", 0) or 0)
+    credits = db.normalize_credit_amount(fresh.get("credits", 0))
     if credits < CREDIT_COST:
         _send_no_credit(bot, message.chat.id, lang, credits)
         _start_prompt_flow(

--- a/modules/image/texts.py
+++ b/modules/image/texts.py
@@ -1,11 +1,12 @@
 """Text helpers for the image generation module."""
 
+import db
 from modules.i18n import t
 from .settings import CREDIT_COST
 
 
 def intro(lang: str) -> str:
-    return t("image_intro", lang).format(cost=CREDIT_COST)
+    return t("image_intro", lang).format(cost=db.format_credit_amount(CREDIT_COST))
 
 
 def processing(lang: str) -> str:
@@ -16,8 +17,11 @@ def error(lang: str) -> str:
     return t("image_error", lang)
 
 
-def no_credit(lang: str, credits: int) -> str:
-    return t("image_no_credit", lang).format(cost=CREDIT_COST, credits=credits)
+def no_credit(lang: str, credits: float) -> str:
+    return t("image_no_credit", lang).format(
+        cost=db.format_credit_amount(CREDIT_COST),
+        credits=db.format_credit_amount(credits),
+    )
 
 
 def not_configured(lang: str) -> str:
@@ -25,7 +29,7 @@ def not_configured(lang: str) -> str:
 
 
 def result_caption(lang: str) -> str:
-    return t("image_result_caption", lang).format(cost=CREDIT_COST)
+    return t("image_result_caption", lang).format(cost=db.format_credit_amount(CREDIT_COST))
 
 
 def need_prompt(lang: str) -> str:

--- a/modules/profile/texts.py
+++ b/modules/profile/texts.py
@@ -1,5 +1,12 @@
+import db
 from modules.i18n import t
 
-def PROFILE_TEXT(lang: str, uid: int, credits: int) -> str:
-    return f"🙋🏼‍♂️ <b>{t('profile_title', lang)}</b>\n\n" + \
-           t('profile_body', lang).format(uid=uid, credits=credits)
+
+def PROFILE_TEXT(lang: str, uid: int, credits: float) -> str:
+    return (
+        f"🙋🏼‍♂️ <b>{t('profile_title', lang)}</b>\n\n"
+        + t("profile_body", lang).format(
+            uid=uid,
+            credits=db.format_credit_amount(credits),
+        )
+    )

--- a/modules/tts/texts.py
+++ b/modules/tts/texts.py
@@ -1,3 +1,4 @@
+import db
 from modules.i18n import t
 
 def TITLE(lang: str) -> str:
@@ -9,13 +10,13 @@ def ask_text(lang: str, voice_name: str) -> str:
 def PROCESSING(lang: str) -> str:
     return t('tts_processing', lang)
 
-def NO_CREDIT(lang: str, credits: int | None = None, required_credits: int | None = None) -> str:
+def NO_CREDIT(lang: str, credits: float | None = None, required_credits: float | None = None) -> str:
     """
     پیام کردیت کافی نیست با فرمت مشخص
     """
-    current_credits = credits if credits is not None else 0
-    required = required_credits if required_credits is not None else 0
-    
+    current_credits = db.format_credit_amount(credits if credits is not None else 0)
+    required = db.format_credit_amount(required_credits if required_credits is not None else 0)
+
     return f"""⚠️ <b>کردیت کافی نیست</b>
 موجـودی شما : <b>{current_credits} Credit</b>
 ➕ کردیـت لازم : <b>{required}</b>

--- a/modules/video/handlers.py
+++ b/modules/video/handlers.py
@@ -80,7 +80,7 @@ def _start_prompt_flow(
         )
 
 
-def _send_no_credit(bot: TeleBot, chat_id: int, lang: str, credits: int) -> None:
+def _send_no_credit(bot: TeleBot, chat_id: int, lang: str, credits: float) -> None:
     bot.send_message(
         chat_id,
         no_credit_text(lang, credits),
@@ -105,7 +105,7 @@ def _process_prompt(bot: TeleBot, message: Message, user, prompt: str, lang: str
         return
 
     fresh = db.get_user(user["user_id"]) or user
-    credits = int(fresh.get("credits", 0) or 0)
+    credits = db.normalize_credit_amount(fresh.get("credits", 0))
     if credits < CREDIT_COST:
         _send_no_credit(bot, message.chat.id, lang, credits)
         _start_prompt_flow(

--- a/modules/video/texts.py
+++ b/modules/video/texts.py
@@ -1,11 +1,12 @@
 """Text helpers for the video generation module."""
 
+import db
 from modules.i18n import t
 from .settings import CREDIT_COST
 
 
 def intro(lang: str) -> str:
-    return t("video_intro", lang).format(cost=CREDIT_COST)
+    return t("video_intro", lang).format(cost=db.format_credit_amount(CREDIT_COST))
 
 
 def processing(lang: str) -> str:
@@ -16,8 +17,11 @@ def error(lang: str) -> str:
     return t("video_error", lang)
 
 
-def no_credit(lang: str, credits: int) -> str:
-    return t("video_no_credit", lang).format(cost=CREDIT_COST, credits=credits)
+def no_credit(lang: str, credits: float) -> str:
+    return t("video_no_credit", lang).format(
+        cost=db.format_credit_amount(CREDIT_COST),
+        credits=db.format_credit_amount(credits),
+    )
 
 
 def not_configured(lang: str) -> str:
@@ -25,4 +29,4 @@ def not_configured(lang: str) -> str:
 
 
 def result_caption(lang: str) -> str:
-    return t("video_result_caption", lang).format(cost=CREDIT_COST)
+    return t("video_result_caption", lang).format(cost=db.format_credit_amount(CREDIT_COST))

--- a/modules/video_gen4/handlers.py
+++ b/modules/video_gen4/handlers.py
@@ -68,7 +68,7 @@ def _start_flow(
         )
 
 
-def _send_no_credit(bot: TeleBot, chat_id: int, lang: str, credits: int) -> None:
+def _send_no_credit(bot: TeleBot, chat_id: int, lang: str, credits: float) -> None:
     bot.send_message(
         chat_id,
         no_credit_text(lang, credits),
@@ -153,7 +153,7 @@ def _process_image(bot: TeleBot, message: Message, user, lang: str) -> None:
         return
 
     fresh = db.get_user(user["user_id"]) or user
-    credits = int(fresh.get("credits", 0) or 0)
+    credits = db.normalize_credit_amount(fresh.get("credits", 0))
     if credits < CREDIT_COST:
         _send_no_credit(bot, message.chat.id, lang, credits)
         _start_flow(bot, message.chat.id, user["user_id"], lang, show_intro=False)

--- a/modules/video_gen4/texts.py
+++ b/modules/video_gen4/texts.py
@@ -1,12 +1,13 @@
 """Text helpers for the Gen-4 video module."""
 
+import db
 from modules.i18n import t
 
 from .settings import CREDIT_COST
 
 
 def intro(lang: str) -> str:
-    return t("video_gen4_intro", lang).format(cost=CREDIT_COST)
+    return t("video_gen4_intro", lang).format(cost=db.format_credit_amount(CREDIT_COST))
 
 
 def processing(lang: str) -> str:
@@ -17,8 +18,11 @@ def error(lang: str) -> str:
     return t("video_gen4_error", lang)
 
 
-def no_credit(lang: str, credits: int) -> str:
-    return t("video_gen4_no_credit", lang).format(cost=CREDIT_COST, credits=credits)
+def no_credit(lang: str, credits: float) -> str:
+    return t("video_gen4_no_credit", lang).format(
+        cost=db.format_credit_amount(CREDIT_COST),
+        credits=db.format_credit_amount(credits),
+    )
 
 
 def not_configured(lang: str) -> str:
@@ -38,4 +42,4 @@ def invalid_file(lang: str) -> str:
 
 
 def result_caption(lang: str) -> str:
-    return t("video_gen4_result_caption", lang).format(cost=CREDIT_COST)
+    return t("video_gen4_result_caption", lang).format(cost=db.format_credit_amount(CREDIT_COST))

--- a/update_user_credits.py
+++ b/update_user_credits.py
@@ -1,10 +1,11 @@
-"""Utility script to recalculate user credits.
+"""Utility script to normalise user credits.
 
 The script connects to the project's database using the configuration provided
-by :mod:`db` and updates every user's ``credits`` value based on an exchange
-rate of 4.5% (0.045). The new value is rounded to the nearest integer before
-being persisted. Before the write operation takes place, the script prints each
-calculated change and waits for user confirmation (unless ``--yes`` is passed).
+by :mod:`db` and updates every user's ``credits`` value so that it contains at
+most two decimal places. Values are rounded using ``ROUND_HALF_UP`` to match
+the behaviour enforced by the runtime helpers. Before the write operation takes
+place, the script prints each calculated change and waits for user confirmation
+(unless ``--yes`` is passed).
 """
 from __future__ import annotations
 
@@ -15,14 +16,18 @@ from typing import Iterable, Tuple
 
 import db
 
-UserChange = Tuple[int, int, int]
+UserChange = Tuple[int, float, float]
 
 
 def _fetch_user_changes(cursor: sqlite3.Cursor) -> Iterable[UserChange]:
     cursor.execute("SELECT user_id, credits FROM users")
     for user_id, credits in cursor.fetchall():
-        old_credits = credits or 0
-        new_credits = round(old_credits * 0.045)
+        old_credits = float(credits or 0)
+        new_credits = db.normalize_credit_amount(old_credits)
+
+        if abs(new_credits - old_credits) < 1e-9:
+            continue
+
         yield user_id, old_credits, new_credits
 
 
@@ -43,13 +48,17 @@ def recalculate_user_credits(*, assume_yes: bool = False) -> None:
         changes = list(_fetch_user_changes(cursor))
 
         if not changes:
-            print("هیچ کاربری در جدول users پیدا نشد.")
+            print("هیچ کاربری در جدول users پیدا نشد یا نیازی به تغییر نبود.")
             return
 
         print("لیست تغییرات پیشنهادی:")
         for user_id, old_credits, new_credits in changes:
             print(
-                f"user_id={user_id} old_credits={old_credits} new_credits={new_credits}"
+                "user_id={user_id} old_credits={old:.5f} new_credits={new:.2f}".format(
+                    user_id=user_id,
+                    old=old_credits,
+                    new=new_credits,
+                )
             )
 
         if not assume_yes:
@@ -70,7 +79,7 @@ def recalculate_user_credits(*, assume_yes: bool = False) -> None:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Recalculate user credits based on a 4.5% exchange rate."
+        description="Normalise all user credits to two decimal places."
     )
     parser.add_argument(
         "--yes",


### PR DESCRIPTION
## Summary
- add shared helpers that normalize and format credit amounts before persisting or returning user data
- update credit-consuming handlers to rely on normalized balances instead of casting to integers
- format user- and admin-facing credit messages through the helper to keep two-decimal precision everywhere

## Testing
- python -m compileall db.py modules

------
https://chatgpt.com/codex/tasks/task_e_68dc1e847d7c8332a68eac9409df04e9