### PR TITLE
Reorder main menu GPT and TTS buttons

### DIFF
--- a/modules/home/keyboards.py
+++ b/modules/home/keyboards.py
@@ -11,11 +11,11 @@ def main_menu(lang: str) -> InlineKeyboardMarkup:
         InlineKeyboardButton(t("btn_credit", lang), callback_data="home:credit"),
     )
     kb.row(
-        InlineKeyboardButton(t("btn_tts", lang), callback_data="home:tts"),
+        InlineKeyboardButton(t("btn_gpt", lang), callback_data="home:gpt_chat"),
         InlineKeyboardButton(t("btn_image", lang), callback_data="home:image"),
     )
     kb.row(
-        InlineKeyboardButton(t("btn_gpt", lang), callback_data="home:gpt_chat"),
+        InlineKeyboardButton(t("btn_tts", lang), callback_data="home:tts"),
     )
     kb.row(
         InlineKeyboardButton(t("btn_lang", lang), callback_data="home:lang"),


### PR DESCRIPTION
## Summary
- swap the placement of the GPT-5 and text-to-speech buttons in the main menu keyboard so GPT-5 sits with the image option

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcda42113083329cb3778618d28f12