### PR TITLE
Add OpenAI text-to-speech option

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ from modules.profile import handlers as profile_handlers
 from modules.credit import handlers as credit_handlers
 from modules.clone import handlers as clone_handlers
 from modules.tts import handlers as tts_handlers
+from modules.tts_openai import handlers as tts_openai_handlers
 from modules.gpt import handlers as gpt_handlers
 from modules.image import handlers as image_handlers
 from modules.video_gen4 import handlers as video_handlers
@@ -35,6 +36,7 @@ def register_modules(bot: telebot.TeleBot) -> None:
     credit_handlers.register (bot)
     clone_handlers.register(bot)
     tts_handlers.register(bot)
+    tts_openai_handlers.register(bot)
     gpt_handlers.register(bot)
     image_handlers.register(bot)
     video_handlers.register(bot)

--- a/modules/tts/keyboards.py
+++ b/modules/tts/keyboards.py
@@ -1,48 +1,83 @@
 # modules/tts/keyboards.py
+from __future__ import annotations
+
 from telebot.types import InlineKeyboardMarkup, InlineKeyboardButton
+
 from modules.i18n import t
 from .settings import VOICES
 import db
 
+
 def _chunk(seq, n):
     for i in range(0, len(seq), n):
-        yield seq[i:i+n]
+        yield seq[i : i + n]
 
-def keyboard(selected_voice: str, lang: str = "fa", user_id: int = None):
+
+def keyboard(
+    selected_voice: str,
+    lang: str = "fa",
+    user_id: int | None = None,
+    *,
+    voices: dict[str, str] | list[str] | None = None,
+    prefix: str = "tts",
+    include_custom: bool = True,
+    quality: str = "pro",
+):
     kb = InlineKeyboardMarkup(row_width=3)
-    
-    # صداهای پیش‌فرض
-    default_names = list(VOICES.keys())
-    
-    # صداهای کاستوم کاربر
+
+    voice_source = voices or VOICES
+    if isinstance(voice_source, dict):
+        default_names = list(voice_source.keys())
+    else:
+        default_names = list(voice_source)
+
     custom_voices = []
-    if user_id:
+    allow_custom = include_custom and user_id is not None
+    if allow_custom:
         try:
             custom_voices = db.list_user_voices(user_id)  # [(voice_name, voice_id), ...]
-        except:
-            pass
-    
-    # ترکیب صداهای پیش‌فرض و کاستوم
-    all_names = default_names + [voice[0] for voice in custom_voices]
-    
-    for row in _chunk(all_names, 3):
-        kb.row(*[
-            InlineKeyboardButton(("✔️ " if n == selected_voice else "") + n,
-                                 callback_data=f"tts:voice:{n}")
-            for n in row
-        ])
+        except Exception:
+            custom_voices = []
+    else:
+        allow_custom = False
 
-    # اگر صدای انتخابی کاستوم هست، دکمه حذف اضافه کن
-    if user_id and selected_voice:
+    all_names = default_names + ([voice[0] for voice in custom_voices] if allow_custom else [])
+
+    for row in _chunk(all_names, 3):
+        kb.row(
+            *[
+                InlineKeyboardButton(
+                    ("✔️ " if n == selected_voice else "") + n,
+                    callback_data=f"{prefix}:voice:{n}",
+                )
+                for n in row
+            ]
+        )
+
+    if allow_custom and selected_voice:
         is_custom = any(voice[0] == selected_voice for voice in custom_voices)
         if is_custom:
-            kb.add(InlineKeyboardButton("🗑 حذف این صدا", callback_data=f"tts:delete:{selected_voice}"))
+            kb.add(
+                InlineKeyboardButton(
+                    "🗑 حذف این صدا", callback_data=f"{prefix}:delete:{selected_voice}"
+                )
+            )
 
-    # دکمه ساخت صدای شخصی همیشه قبل از بازگشت باشد
+    kb.row(
+        InlineKeyboardButton(
+            ("✔️ " if quality == "pro" else "") + "کیفیت حرفه‌ای",
+            callback_data=f"{prefix}:quality:pro",
+        ),
+        InlineKeyboardButton(
+            ("✔️ " if quality == "medium" else "") + "کیفیت متوسط",
+            callback_data=f"{prefix}:quality:medium",
+        ),
+    )
+
     kb.add(InlineKeyboardButton(t("btn_clone", lang), callback_data="home:clone"))
-
     kb.add(InlineKeyboardButton(t("back", lang), callback_data="home:back"))
     return kb
+
 
 def no_credit_keyboard(lang: str = "fa"):
     """کیبورد برای پیام کردیت کافی نیست"""

--- a/modules/tts_openai/__init__.py
+++ b/modules/tts_openai/__init__.py
@@ -1,0 +1,2 @@
+"""OpenAI Text-to-Speech module."""
+

--- a/modules/tts_openai/handlers.py
+++ b/modules/tts_openai/handlers.py
@@ -1,0 +1,250 @@
+"""Handlers for OpenAI-powered text-to-speech."""
+
+from __future__ import annotations
+
+from io import BytesIO
+import time
+
+import db
+from utils import edit_or_send
+from modules.tts.texts import ask_text, PROCESSING, NO_CREDIT, ERROR, BANNED
+from modules.tts.keyboards import no_credit_keyboard
+from .keyboards import keyboard as tts_keyboard
+from .settings import (
+    STATE_WAIT_TEXT,
+    VOICES,
+    DEFAULT_VOICE_NAME,
+    CREDIT_PER_CHAR,
+    OUTPUTS,
+    BANNED_WORDS,
+)
+from .service import synthesize
+
+
+_NORMALIZE_REPLACEMENTS = {
+    "ك": "ک",
+    "ي": "ی",
+    "ى": "ی",
+    "ؤ": "و",
+    "إ": "ا",
+    "أ": "ا",
+    "آ": "ا",
+    "ة": "ه",
+    "ۀ": "ه",
+}
+
+
+def _normalize_text(text: str) -> str:
+    normalized = (text or "").lower()
+    for src, dst in _NORMALIZE_REPLACEMENTS.items():
+        normalized = normalized.replace(src, dst)
+    return normalized.replace("ـ", "").replace("\u200c", " ").replace("\u200d", "")
+
+
+_BANNED_WORDS = tuple(_normalize_text(word) for word in BANNED_WORDS if word)
+
+
+def _has_banned_word(text: str) -> bool:
+    normalized = _normalize_text(text)
+    return any(word and word in normalized for word in _BANNED_WORDS)
+
+
+def _parse_state(raw: str):
+    parts = (raw or "").split(":")
+    menu_id = int(parts[2]) if len(parts) >= 3 and parts[2].isdigit() else None
+    voice_name = parts[3] if len(parts) >= 4 else DEFAULT_VOICE_NAME
+    return menu_id, voice_name
+
+
+def _make_state(menu_id: int, voice_name: str) -> str:
+    return f"{STATE_WAIT_TEXT}:{menu_id}:{voice_name}"
+
+
+def safe_del(bot, chat_id, message_id):
+    if not chat_id or not message_id:
+        return
+    try:
+        bot.delete_message(chat_id, message_id)
+    except Exception:
+        pass
+
+
+def register(bot):
+    @bot.callback_query_handler(func=lambda c: c.data and c.data.startswith("tts_openai:"))
+    def tts_openai_router(cq):
+        user = db.get_or_create_user(cq.from_user)
+        lang = db.get_user_lang(user["user_id"], "fa")
+
+        route = cq.data.split(":", 1)[1]
+
+        if route == "quality:medium":
+            state = db.get_state(cq.from_user.id) or ""
+            _, voice_name = _parse_state(state)
+            if voice_name not in VOICES:
+                voice_name = DEFAULT_VOICE_NAME
+
+            edit_or_send(
+                bot,
+                cq.message.chat.id,
+                cq.message.message_id,
+                ask_text(lang, voice_name),
+                tts_keyboard(voice_name, lang, user["user_id"]),
+            )
+            db.set_state(cq.from_user.id, _make_state(cq.message.message_id, voice_name))
+            bot.answer_callback_query(cq.id, "کیفیت متوسط")
+            return
+
+        if route == "quality:pro":
+            from modules.tts.handlers import open_tts as open_pro_tts
+
+            open_pro_tts(bot, cq)
+            bot.answer_callback_query(cq.id, "کیفیت حرفه‌ای")
+            return
+
+        if route.startswith("voice:"):
+            name = route.split(":", 1)[1]
+            if name not in VOICES:
+                bot.answer_callback_query(cq.id, "Voice not found")
+                return
+
+            edit_or_send(
+                bot,
+                cq.message.chat.id,
+                cq.message.message_id,
+                ask_text(lang, name),
+                tts_keyboard(name, lang, user["user_id"]),
+            )
+            db.set_state(cq.from_user.id, _make_state(cq.message.message_id, name))
+            bot.answer_callback_query(cq.id, name)
+            return
+
+    @bot.message_handler(
+        func=lambda m: (db.get_state(m.from_user.id) or "").startswith(STATE_WAIT_TEXT),
+        content_types=["text"],
+    )
+    def on_text_to_tts(msg):
+        user = db.get_or_create_user(msg.from_user)
+        user_id = user["user_id"]
+
+        current_state = db.get_state(user_id) or ""
+
+        if current_state.startswith("tts_openai:processing"):
+            return
+
+        db.set_state(user_id, f"tts_openai:processing:{int(time.time())}")
+
+        cost = 0
+        status = None
+        try:
+            lang = db.get_user_lang(user_id, "fa")
+
+            from utils import check_force_sub
+
+            settings = db.get_settings()
+            mode = (settings.get("FORCE_SUB_MODE") or "none").lower()
+            if mode in ("new", "all"):
+                ok, txt, kb = check_force_sub(bot, user_id, settings, lang)
+                if not ok:
+                    edit_or_send(bot, msg.chat.id, msg.message_id, txt, kb)
+                    return
+
+            last_menu_id, voice_name = _parse_state(current_state)
+            voice_id = VOICES.get(voice_name)
+            if not voice_id:
+                voice_name = DEFAULT_VOICE_NAME
+                voice_id = VOICES[voice_name]
+
+            text = (msg.text or "").strip()
+            if not text:
+                return
+
+            if _has_banned_word(text):
+                bot.send_message(msg.chat.id, BANNED(lang))
+                db.set_state(user_id, _make_state(last_menu_id or msg.message_id, voice_name))
+                return
+
+            try:
+                db.log_tts_request(user_id, text)
+            except Exception:
+                pass
+
+            cost = db.normalize_credit_amount(len(text) * CREDIT_PER_CHAR)
+            balance = db.normalize_credit_amount(user.get("credits", 0))
+            if balance < cost:
+                bot.send_message(
+                    msg.chat.id,
+                    NO_CREDIT(lang, balance, cost),
+                    reply_markup=no_credit_keyboard(lang),
+                )
+                return
+
+            if not db.deduct_credits(user_id, cost):
+                refreshed = db.get_user(user_id) or {}
+                new_balance = db.normalize_credit_amount(refreshed.get("credits", 0))
+                bot.send_message(
+                    msg.chat.id,
+                    NO_CREDIT(lang, new_balance, cost),
+                    reply_markup=no_credit_keyboard(lang),
+                )
+                return
+
+            status = bot.send_message(msg.chat.id, PROCESSING(lang))
+
+            print(
+                f"🔥 OPENAI TTS REQUEST: user={user_id}, text_len={len(text)}, voice={voice_name}"
+            )
+            audio_data = synthesize(text, voice_id, OUTPUTS[0]["mime"])
+            print(
+                f"✅ OPENAI TTS RESPONSE: user={user_id}, audio_size={len(audio_data)} bytes"
+            )
+
+            safe_del(bot, status.chat.id if status else None, status.message_id if status else None)
+            if last_menu_id:
+                safe_del(bot, msg.chat.id, last_menu_id)
+
+            bio = BytesIO(audio_data)
+            bio.name = "Vexa.mp3"
+            bot.send_document(msg.chat.id, document=bio)
+
+            new_menu = bot.send_message(
+                msg.chat.id,
+                ask_text(lang, voice_name),
+                reply_markup=tts_keyboard(voice_name, lang, user_id),
+            )
+            db.set_state(user_id, _make_state(new_menu.message_id, voice_name))
+
+        except Exception as e:
+            try:
+                if cost:
+                    db.add_credits(user_id, cost)
+                    print(
+                        f"❌ OPENAI TTS ERROR: user={user_id}, credits refunded={cost}, error={e}"
+                    )
+            except Exception:
+                pass
+
+            if status:
+                safe_del(bot, status.chat.id, status.message_id)
+            err = ERROR(lang)
+            bot.send_message(msg.chat.id, err)
+            db.clear_state(user_id)
+
+        finally:
+            current = db.get_state(user_id) or ""
+            if current.startswith("tts_openai:processing"):
+                db.clear_state(user_id)
+
+
+def open_tts(bot, cq, voice_name: str | None = None):
+    user = db.get_or_create_user(cq.from_user)
+    lang = db.get_user_lang(user["user_id"], "fa")
+    sel = voice_name if voice_name in VOICES else DEFAULT_VOICE_NAME
+    edit_or_send(
+        bot,
+        cq.message.chat.id,
+        cq.message.message_id,
+        ask_text(lang, sel),
+        tts_keyboard(sel, lang, user["user_id"]),
+    )
+    db.set_state(cq.from_user.id, _make_state(cq.message.message_id, sel))
+

--- a/modules/tts_openai/keyboards.py
+++ b/modules/tts_openai/keyboards.py
@@ -1,0 +1,19 @@
+"""Keyboards for the OpenAI TTS flow."""
+
+from __future__ import annotations
+
+from modules.tts.keyboards import keyboard as base_keyboard
+from .settings import VOICES
+
+
+def keyboard(selected_voice: str, lang: str = "fa", user_id: int | None = None):
+    return base_keyboard(
+        selected_voice,
+        lang,
+        user_id,
+        voices=VOICES,
+        prefix="tts_openai",
+        include_custom=False,
+        quality="medium",
+    )
+

--- a/modules/tts_openai/service.py
+++ b/modules/tts_openai/service.py
@@ -1,0 +1,40 @@
+"""HTTP client for OpenAI text-to-speech."""
+
+from __future__ import annotations
+
+import json
+from typing import Final
+
+import requests
+
+from modules.gpt.service import resolve_gpt_api_key
+
+_OPENAI_TTS_URL: Final[str] = "https://api.openai.com/v1/audio/speech"
+_MODEL_ID: Final[str] = "gpt-4o-mini-tts"
+
+
+def synthesize(text: str, voice: str, mime: str = "audio/mpeg") -> bytes:
+    api_key = resolve_gpt_api_key()
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY is missing")
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "Accept": mime,
+    }
+    payload = {
+        "model": _MODEL_ID,
+        "voice": voice,
+        "input": text,
+    }
+
+    response = requests.post(
+        _OPENAI_TTS_URL,
+        headers=headers,
+        data=json.dumps(payload),
+        timeout=120,
+    )
+    response.raise_for_status()
+    return response.content
+

--- a/modules/tts_openai/settings.py
+++ b/modules/tts_openai/settings.py
@@ -1,0 +1,33 @@
+"""Settings for the OpenAI text-to-speech flow."""
+
+from __future__ import annotations
+
+from modules.tts.settings import BANNED_WORDS as BASE_BANNED_WORDS
+
+
+STATE_WAIT_TEXT = "tts_openai:wait_text"
+
+# هر کاراکتر = 0.01 کردیت برای TTS اوپن‌اِی‌آی
+CREDIT_PER_CHAR = 0.01
+
+# صدای پیش‌فرض (وقتی هنوز انتخابی انجام نشده)
+DEFAULT_VOICE_NAME = "Echo"
+
+# نام صدا → مقدار موردنیاز برای API
+VOICES = {
+    "Echo": "echo",
+    "Nova": "nova",
+    "Alloy": "alloy",
+    "Ash": "ash",
+    "Marin": "marin",
+    "Shimmer": "shimmer",
+}
+
+# خروجی‌ها (فرمت MP3)
+OUTPUTS = [
+    {"mime": "audio/mpeg"},
+]
+
+# همان فهرست کلمات غیرمجاز TTS اصلی
+BANNED_WORDS = list(BASE_BANNED_WORDS)
+


### PR DESCRIPTION
## Summary
- add an OpenAI-backed medium quality TTS flow with dedicated handlers, voices, and billing rules
- extend the existing TTS keyboards to expose professional/medium quality toggles and reuse them for OpenAI voices
- register the new module so the bot can route between ElevenLabs and OpenAI menus

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68dd6c16af7c833281db9d90ac582ac1