### PR TITLE
Fix TTS professional voice selection and hide demo link on medium quality

### DIFF
--- a/modules/tts/handlers.py
+++ b/modules/tts/handlers.py
@@ -111,14 +111,14 @@ def register(bot):
                 bot.answer_callback_query(cq.id, "Voice not found"); return
 
             # منوی «متن را بفرست» با صدای انتخابی
-                edit_or_send(
-                    bot,
-                    cq.message.chat.id,
-                    cq.message.message_id,
-                    ask_text(lang, name),
-                    tts_keyboard(name, lang, user["user_id"], quality="pro")
-                )
-                db.set_state(cq.from_user.id, _make_state(cq.message.message_id, name))
+            edit_or_send(
+                bot,
+                cq.message.chat.id,
+                cq.message.message_id,
+                ask_text(lang, name),
+                tts_keyboard(name, lang, user["user_id"], quality="pro"),
+            )
+            db.set_state(cq.from_user.id, _make_state(cq.message.message_id, name))
             bot.answer_callback_query(cq.id, name)
             return
 

--- a/modules/tts/texts.py
+++ b/modules/tts/texts.py
@@ -10,10 +10,16 @@ def ask_text(
     voice_name: str,
     *,
     credit_per_char: float | int | str | None = None,
+    show_demo_link: bool = True,
 ) -> str:
     credit_value = credit_per_char if credit_per_char is not None else PRO_CREDIT_PER_CHAR
     credit_text = db.format_credit_amount(credit_value)
     prompt = t("tts_prompt", lang).format(credit=credit_text)
+
+    if not show_demo_link and lang == "fa":
+        prompt = prompt.replace("\n<b><a href='https://t.me/VexaOrder/6'>دموی صداها</a></b>", "")
+
+    prompt = prompt.strip()
     return f"{TITLE(lang)}\n\n{prompt}\n\n🎙 <b>{voice_name}</b>"
 
 def PROCESSING(lang: str) -> str:

--- a/modules/tts_openai/handlers.py
+++ b/modules/tts_openai/handlers.py
@@ -88,7 +88,12 @@ def register(bot):
                 bot,
                 cq.message.chat.id,
                 cq.message.message_id,
-                ask_text(lang, voice_name, credit_per_char=CREDIT_PER_CHAR),
+                ask_text(
+                    lang,
+                    voice_name,
+                    credit_per_char=CREDIT_PER_CHAR,
+                    show_demo_link=False,
+                ),
                 tts_keyboard(voice_name, lang, user["user_id"]),
             )
             db.set_state(cq.from_user.id, _make_state(cq.message.message_id, voice_name))
@@ -112,7 +117,12 @@ def register(bot):
                 bot,
                 cq.message.chat.id,
                 cq.message.message_id,
-                ask_text(lang, name, credit_per_char=CREDIT_PER_CHAR),
+                ask_text(
+                    lang,
+                    name,
+                    credit_per_char=CREDIT_PER_CHAR,
+                    show_demo_link=False,
+                ),
                 tts_keyboard(name, lang, user["user_id"]),
             )
             db.set_state(cq.from_user.id, _make_state(cq.message.message_id, name))
@@ -209,7 +219,12 @@ def register(bot):
 
             new_menu = bot.send_message(
                 msg.chat.id,
-                ask_text(lang, voice_name, credit_per_char=CREDIT_PER_CHAR),
+                ask_text(
+                    lang,
+                    voice_name,
+                    credit_per_char=CREDIT_PER_CHAR,
+                    show_demo_link=False,
+                ),
                 reply_markup=tts_keyboard(voice_name, lang, user_id),
             )
             db.set_state(user_id, _make_state(new_menu.message_id, voice_name))
@@ -244,7 +259,12 @@ def open_tts(bot, cq, voice_name: str | None = None):
         bot,
         cq.message.chat.id,
         cq.message.message_id,
-        ask_text(lang, sel, credit_per_char=CREDIT_PER_CHAR),
+        ask_text(
+            lang,
+            sel,
+            credit_per_char=CREDIT_PER_CHAR,
+            show_demo_link=False,
+        ),
         tts_keyboard(sel, lang, user["user_id"]),
     )
     db.set_state(cq.from_user.id, _make_state(cq.message.message_id, sel))


### PR DESCRIPTION
## Summary
- fix the professional quality voice selection handler so the chosen voice updates correctly
- allow the TTS prompt builder to optionally hide the demo link when the professional tier is not selected
- hide the demo link across the medium quality/OpenAI flow so it only appears for professional voices

## Testing
- python -m compileall modules/tts modules/tts_openai

------
https://chatgpt.com/codex/tasks/task_e_68dd7a8908748332bb1a232076416248