### PR TITLE
Add daily reward claim button to invite menu

### DIFF
--- a/modules/i18n.py
+++ b/modules/i18n.py
@@ -450,6 +450,36 @@ LABELS = {
     # Invite
     "invite_title":   {"fa":"دعوت دوستان 🎁","en":"Invite Friends 🎁","ar":"دعوة الأصدقاء 🎁","tr":"Arkadaş Davet Et 🎁","ru":"Пригласить друзей 🎁","es":"Invitar amigos 🎁","de":"Freunde einladen 🎁","fr":"Inviter des amis 🎁"},
     "invite_body":    {"fa":"لینک دعوت شما:\n<code>{ref}</code>\n\n<b>به ازای هر دعوت : +{bonus} کردیت</b>","en":"Your invite link:\n{ref}\nPer invite: {bonus} credits","ar":"رابط دعوتك:\n{ref}\nلكل دعوة: {bonus} رصيد","tr":"Davet bağlantın:\n{ref}\nDavet başına: {bonus} kredi","ru":"Ваша ссылка:\n{ref}\nЗа приглашение: {bonus} кредитов","es":"Tu enlace de invitación:\n{ref}\nPor invitación: {bonus} créditos","de":"Dein Einladungslink:\n{ref}\nPro Einladung: {bonus} Guthaben","fr":"Ton lien d'invitation :\n{ref}\nPar invitation : {bonus} crédits"},
+    "invite_daily_reward": {
+        "fa": "دریافت پاداش روزانه 🎁",
+        "en": "Claim daily reward 🎁",
+        "ar": "استلام مكافأة يومية 🎁",
+        "tr": "Günlük ödülü al 🎁",
+        "ru": "Получить дневной бонус 🎁",
+        "es": "Reclamar recompensa diaria 🎁",
+        "de": "Tägliche Belohnung holen 🎁",
+        "fr": "Obtenir la récompense quotidienne 🎁",
+    },
+    "invite_daily_reward_success": {
+        "fa": "🎉 امروز {amount} کردیت به عنوان پاداش روزانه گرفتی!",
+        "en": "🎉 You received {amount} credits as today's daily reward!",
+        "ar": "🎉 حصلت اليوم على {amount} رصيد كمكافأة يومية!",
+        "tr": "🎉 Bugünkü günlük ödül olarak {amount} kredi kazandın!",
+        "ru": "🎉 Ты получил сегодня {amount} кредитов как ежедневный бонус!",
+        "es": "🎉 ¡Recibiste {amount} créditos como recompensa diaria de hoy!",
+        "de": "🎉 Du hast heute {amount} Credits als tägliche Belohnung erhalten!",
+        "fr": "🎉 Tu as reçu {amount} crédits comme récompense quotidienne d'aujourd'hui !",
+    },
+    "invite_daily_reward_cooldown": {
+        "fa": "⏳ قبلاً پاداش امروز رو گرفتی. بعد از {time} دوباره تلاش کن.",
+        "en": "⏳ You've already claimed today's reward. Try again in {time}.",
+        "ar": "⏳ لقد استلمت مكافأة اليوم بالفعل. جرّب بعد {time}.",
+        "tr": "⏳ Bugünkü ödülü zaten aldın. {time} sonra tekrar dene.",
+        "ru": "⏳ Ты уже получил сегодняшний бонус. Попробуй снова через {time}.",
+        "es": "⏳ Ya reclamaste la recompensa de hoy. Vuelve en {time}.",
+        "de": "⏳ Du hast die heutige Belohnung schon erhalten. Versuche es in {time} erneut.",
+        "fr": "⏳ Tu as déjà récupéré la récompense d'aujourd'hui. Réessaie dans {time}.",
+    },
 }
 
 def t(key: str, lang: str) -> str:

--- a/modules/invite/handlers.py
+++ b/modules/invite/handlers.py
@@ -1,11 +1,55 @@
 # modules/invite/handlers.py
+from __future__ import annotations
+
+import time
+
+from telebot import TeleBot
+from telebot.types import CallbackQuery
+
 import db
+from modules.i18n import t
 from utils import edit_or_send
 from .texts import INVITE_TEXT
 from .keyboards import keyboard as invite_keyboard
 
-def register(bot):
-    pass
+
+DAILY_REWARD_AMOUNT = 0.1
+DAILY_REWARD_INTERVAL = 24 * 60 * 60
+
+
+def register(bot: TeleBot) -> None:
+    @bot.callback_query_handler(func=lambda c: c.data == "invite:daily_reward")
+    def handle_daily_reward(cq: CallbackQuery) -> None:
+        user = db.get_or_create_user(cq.from_user)
+        user_id = user["user_id"]
+        lang = db.get_user_lang(user_id, "fa")
+
+        if user.get("banned"):
+            bot.answer_callback_query(cq.id, t("error_banned", lang), show_alert=True)
+            return
+
+        db.touch_last_seen(user_id)
+
+        now = int(time.time())
+        last_claim = db.get_last_daily_reward(user_id)
+        if now - last_claim >= DAILY_REWARD_INTERVAL:
+            db.add_credits(user_id, DAILY_REWARD_AMOUNT)
+            db.set_last_daily_reward(user_id, now)
+            amount_text = db.format_credit_amount(DAILY_REWARD_AMOUNT)
+            bot.answer_callback_query(
+                cq.id,
+                t("invite_daily_reward_success", lang).format(amount=amount_text),
+                show_alert=True,
+            )
+            return
+
+        remaining = max(0, DAILY_REWARD_INTERVAL - (now - last_claim))
+        remaining_text = _format_remaining_time(remaining)
+        bot.answer_callback_query(
+            cq.id,
+            t("invite_daily_reward_cooldown", lang).format(time=remaining_text),
+            show_alert=True,
+        )
 
 def open_invite(bot, cq):
     user = db.get_or_create_user(cq.from_user)
@@ -14,3 +58,10 @@ def open_invite(bot, cq):
     me = bot.get_me()
     ref_url = f"https://t.me/{me.username}?start={user['ref_code']}"
     edit_or_send(bot, cq.message.chat.id, cq.message.message_id, INVITE_TEXT(lang, ref_url, bonus), invite_keyboard(lang))
+
+
+def _format_remaining_time(seconds: int) -> str:
+    seconds = max(0, int(seconds))
+    hours, remainder = divmod(seconds, 3600)
+    minutes, _ = divmod(remainder, 60)
+    return f"{hours:02d}:{minutes:02d}"

--- a/modules/invite/keyboards.py
+++ b/modules/invite/keyboards.py
@@ -5,6 +5,7 @@ from modules.i18n import t
 def keyboard(lang: str = "fa"):
     kb = InlineKeyboardMarkup()
     kb.add(InlineKeyboardButton(t("back", lang), callback_data="home:back"))
+    kb.add(InlineKeyboardButton(t("invite_daily_reward", lang), callback_data="invite:daily_reward"))
     return kb
 
 def back_keyboard(lang: str = "fa"):


### PR DESCRIPTION
## Summary
- add a daily reward claim button to the invite friends menu and handle the callback
- persist last claimed timestamps and internationalized texts for the new reward flow

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68dd8e87ed2883328b4288e68e5177d0