### PR TITLE
Set Vexa assistant ID

### DIFF
--- a/config.py
+++ b/config.py
@@ -91,12 +91,7 @@ GPT_ASSISTANT_ID = (
     or ""
 ).strip()
 
-VEXA_ASSISTANT_ID = (
-    os.getenv("VEXA_ASSISTANT")
-    or os.getenv("VEXA_ASSISTANT_ID")
-    or os.getenv("OPENAI_VEXA_ASSISTANT_ID")
-    or ""
-).strip()
+VEXA_ASSISTANT_ID = "asst_wS0b82xEC1HTZzXqlPFMA61c"
 
 VEXA_ASSISTANT_API_KEY = _first_non_empty(
     os.getenv("VEXA_ASSISTANT_API_KEY"),


### PR DESCRIPTION
## Summary
- hardcode the Vexa assistant configuration to the provided assistant id

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de84b0a4548332a354f1cc2ff04edf