### PR TITLE
Fix assistant payload to avoid unsupported parameter error

### DIFF
--- a/modules/gpt/service.py
+++ b/modules/gpt/service.py
@@ -15,7 +15,6 @@ from config import (
     GPT_API_KEY_PREFIX,
     GPT_API_TIMEOUT,
     GPT_API_URL,
-    GPT_ASSISTANT_ID,
     GPT_MAX_TOKENS,
     GPT_MODEL,
     GPT_MODE,
@@ -329,9 +328,6 @@ def _prepare_assistant_payload(
         "temperature": temperature if temperature is not None else GPT_TEMPERATURE,
         "top_p": top_p if top_p is not None else GPT_TOP_P,
     }
-
-    if GPT_ASSISTANT_ID:
-        payload["assistant_id"] = GPT_ASSISTANT_ID
 
     limit = max_tokens if max_tokens is not None else GPT_MAX_TOKENS
     if limit > 0:

--- a/modules/vexa_assistant/handlers.py
+++ b/modules/vexa_assistant/handlers.py
@@ -41,7 +41,7 @@ def _ensure_ready(lang: str) -> str | None:
     ok, error = ensure_ready()
     if ok:
         return None
-    if error in {"missing_api_key", "missing_assistant_id"}:
+    if error in {"missing_api_key"}:
         return t("vexa_assistant_not_configured", lang)
     return t("vexa_assistant_error", lang).format(error=html.escape(str(error)))
 

--- a/modules/vexa_assistant/service.py
+++ b/modules/vexa_assistant/service.py
@@ -14,7 +14,6 @@ from config import (
     GPT_API_TIMEOUT,
     VEXA_ASSISTANT_API_KEY,
     VEXA_ASSISTANT_API_URL,
-    VEXA_ASSISTANT_ID,
     VEXA_ASSISTANT_MODEL,
 )
 from modules.gpt.service import extract_message_text, resolve_gpt_api_key
@@ -58,8 +57,6 @@ def ensure_ready(force_refresh: bool = False) -> tuple[bool, Optional[str]]:
     key = resolve_api_key(force_refresh=force_refresh)
     if not key:
         return False, "missing_api_key"
-    if not VEXA_ASSISTANT_ID:
-        return False, "missing_assistant_id"
     return True, None
 
 
@@ -76,9 +73,6 @@ def prepare_messages(history: List[Dict[str, Any]]) -> Dict[str, Any]:
         "model": (VEXA_ASSISTANT_MODEL or "gpt-4o-mini").strip() or "gpt-4o-mini",
         "input": normalised,
     }
-
-    if VEXA_ASSISTANT_ID:
-        payload["assistant_id"] = VEXA_ASSISTANT_ID
 
     return payload
 


### PR DESCRIPTION
## Summary
- remove the assistant_id field from the OpenAI Responses payload to match the current API
- relax the Vexa assistant readiness check and handler messaging now that assistant_id is no longer required

## Testing
- python -m compileall modules/gpt/service.py modules/vexa_assistant/service.py modules/vexa_assistant/handlers.py

------
https://chatgpt.com/codex/tasks/task_e_68de8a62ea14833294c6752b3daaa38d