### PR TITLE
Ensure Vexa assistant threads can invoke web search

### DIFF
--- a/modules/vexa_assistant/service.py
+++ b/modules/vexa_assistant/service.py
@@ -610,6 +610,13 @@ def request_response(history: List[Dict[str, Any]]) -> str:
 
     try:
         run_kwargs: Dict[str, Any] = {"thread_id": thread.id, "assistant_id": assistant_id}
+        # Ensure the OpenAI run has access to the locally implemented tools (such as
+        # ``web_search``).  Some deployments rely on supplying tools dynamically
+        # instead of configuring them on the remote assistant.  Without this the
+        # assistant would never be able to request a web search, even if it tries
+        # to do so, which is the root cause of search being unavailable in the
+        # bot.
+        run_kwargs["tools"] = _RESPONSE_TOOLS
         if model_override:
             run_kwargs["model"] = model_override
         run = client.beta.threads.runs.create(**run_kwargs)


### PR DESCRIPTION
## Summary
- ensure assistant runs created via the Threads API include the locally implemented response tools
- allow the Vexa assistant to invoke the web_search helper even when using a preconfigured assistant id

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dea25047988332ab5da09d447103d3