### PR TITLE
Add admin listing for daily reward users

### DIFF
--- a/modules/admin/handlers.py
+++ b/modules/admin/handlers.py
@@ -30,6 +30,7 @@ from .keyboards import (
     exports_menu,
     image_users_menu,
     gpt_users_menu,
+    daily_reward_users_menu,
 )
 from modules.lang.keyboards import LANGS
 
@@ -250,11 +251,16 @@ def register(bot):
                 gpt_users = db.count_users_with_gpt()
             except AttributeError:
                 gpt_users = 0
+            try:
+                daily_reward_users = db.count_daily_reward_users()
+            except AttributeError:
+                daily_reward_users = 0
             txt = (f"📊 <b>آمار</b>\n\n"
                    f"👥 کل کاربران: <b>{total}</b>\n"
                    f"⚡️ فعال ۲۴ساعت: <b>{active24}</b>\n"
                    f"🖼️ کاربران تولید تصویر: <b>{image_users}</b>\n"
-                   f"🤖 کاربران GPT: <b>{gpt_users}</b>")
+                   f"🤖 کاربران GPT: <b>{gpt_users}</b>\n"
+                   f"🎁 پاداش روزانه: <b>{daily_reward_users}</b>")
             edit_or_send(bot, cq.message.chat.id, cq.message.message_id, txt, admin_menu())
             return
 
@@ -332,6 +338,32 @@ def register(bot):
                     cq.message.message_id,
                     "🤖 کاربران GPT:",
                     gpt_users_menu(),
+                )
+            return
+
+        if action == "daily_reward_users":
+            if len(p) >= 4 and p[2] in ("prev", "next"):
+                page = int(p[3])
+                page = max(0, page - 1) if p[2] == "prev" else page + 1
+                edit_or_send(
+                    bot,
+                    cq.message.chat.id,
+                    cq.message.message_id,
+                    "🎁 کاربران پاداش روزانه:",
+                    daily_reward_users_menu(page),
+                )
+            else:
+                count = 0
+                try:
+                    count = db.count_daily_reward_users()
+                except AttributeError:
+                    count = 0
+                edit_or_send(
+                    bot,
+                    cq.message.chat.id,
+                    cq.message.message_id,
+                    f"🎁 کاربران پاداش روزانه: <b>{count}</b>",
+                    daily_reward_users_menu(),
                 )
             return
 

--- a/modules/admin/keyboards.py
+++ b/modules/admin/keyboards.py
@@ -18,6 +18,7 @@ def admin_menu():
         InlineKeyboardButton("🖼️ کاربران تصویر", callback_data="admin:image_users"),
         InlineKeyboardButton("🤖 کاربران GPT", callback_data="admin:gpt_users"),
     )
+    kb.add(InlineKeyboardButton("🎁 پاداش روزانه", callback_data="admin:daily_reward_users"))
     kb.row(
         InlineKeyboardButton("➕ افزودن کردیت", callback_data="admin:add"),
         InlineKeyboardButton("➖ کسر کردیت", callback_data="admin:sub"),
@@ -155,6 +156,40 @@ def gpt_users_menu(page: int = 0, page_size: int = 10):
         nav.append(InlineKeyboardButton("◀️ قبلی", callback_data=f"admin:gpt_users:prev:{page}"))
     if len(rows) == page_size:
         nav.append(InlineKeyboardButton("بعدی ▶️", callback_data=f"admin:gpt_users:next:{page}"))
+    if nav:
+        kb.row(*nav)
+
+    kb.add(InlineKeyboardButton("⬅️ بازگشت", callback_data="admin:menu"))
+    return kb
+
+
+def daily_reward_users_menu(page: int = 0, page_size: int = 10):
+    page = max(0, int(page))
+    offset = page * page_size
+    rows = db.list_daily_reward_users(limit=page_size, offset=offset)
+
+    kb = InlineKeyboardMarkup()
+    if not rows:
+        kb.add(InlineKeyboardButton("— کاربری یافت نشد —", callback_data="admin:noop"))
+    else:
+        for row in rows:
+            uid = row.get("user_id")
+            username = row.get("username")
+            banned = bool(row.get("banned"))
+            credits = row.get("credits") or 0
+            last_ts = row.get("last_daily_reward")
+            label = f"{'🚫' if banned else '✅'} {uid}"
+            if username:
+                label += f" · @{username}"
+            label += f" · 💳 {db.format_credit_amount(credits)}"
+            label += f" · 🕒 {_format_ts(last_ts)}"
+            kb.add(InlineKeyboardButton(label, callback_data=f"admin:user:{uid}"))
+
+    nav = []
+    if page > 0:
+        nav.append(InlineKeyboardButton("◀️ قبلی", callback_data=f"admin:daily_reward_users:prev:{page}"))
+    if len(rows) == page_size:
+        nav.append(InlineKeyboardButton("بعدی ▶️", callback_data=f"admin:daily_reward_users:next:{page}"))
     if nav:
         kb.row(*nav)
 


### PR DESCRIPTION
## Summary
- add database helpers to list and count daily reward participants
- extend admin menu and stats to surface daily reward usage details
- provide a paginated admin view of users who have claimed the daily reward

## Testing
- python -m compileall db.py modules/admin

------
https://chatgpt.com/codex/tasks/task_e_68dfda654b248332a60018ac609993d3