### PR TITLE
Add Cloudflare Workers migration scaffold with D1/DO storage and shared HTTP API

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,37 @@ X-API-Key: <TOKEN>
 | GET  | `/v1/voices` | فهرست صداهای قابل استفاده | ۰ |
 
 خروجی `POST /v1/image` لینک مستقیم تصویر است. خروجی `POST /v1/tts` شامل محتوای صوتی base64 و موجودی باقی‌ماندهٔ کاربر می‌شود. تمام هزینه‌ها از همان موجودی کردیت حساب تلگرام کسر خواهد شد.
+
+---
+
+## Staged Cloudflare migration (new)
+
+A new Workers-based shared backend scaffold has been added under `workers-backend/`.
+
+### Why
+
+To support all three clients on one backend:
+1. Telegram bot (webhook)
+2. Telegram Mini App
+3. Website
+
+### What is included now
+
+- Worker entrypoint and route layout: `workers-backend/src/index.ts`
+- Storage abstraction and D1-backed repositories:
+  - `workers-backend/src/storage/contracts.ts`
+  - `workers-backend/src/storage/d1-repositories.ts`
+- Durable Object for per-user strongly consistent state:
+  - `workers-backend/src/storage/user-state-do.ts`
+- Telegram Mini App init data validation:
+  - `workers-backend/src/auth/telegram.ts`
+- Telegram webhook transport handler:
+  - `workers-backend/src/telegram/webhook.ts`
+- Initial D1 schema:
+  - `workers-backend/migrations/0001_initial.sql`
+- Migration phase notes:
+  - `docs/migration/staged-workers-migration.md`
+
+### Current status
+
+This is phase-0 scaffolding for a staged migration. The polling Python bot remains as legacy runtime until feature-by-feature cutover is complete.

--- a/docs/migration/staged-workers-migration.md
+++ b/docs/migration/staged-workers-migration.md
@@ -1,0 +1,50 @@
+# Staged migration plan: Python polling bot ➜ Cloudflare Workers shared backend
+
+## Repository inspection summary
+
+### What can be reused
+
+1. **Feature-level domain behavior already exists** inside service modules such as image, TTS, clone, GPT, and video. The core business actions (e.g. credit charging, generation flow) are conceptually reusable if detached from TeleBot update objects.
+2. **Data model concepts in `db.py`** (users, credits, API tokens, GPT history, generated assets, cloned voices) are reusable as schema/contracts, even if the implementation must change.
+3. **Existing FastAPI endpoint design** in `api_server.py` can seed the HTTP-first API shape for all clients.
+4. **Localization text catalogs and feature flags** can be reused as part of service responses.
+
+### What must be rewritten
+
+1. **Transport wiring in `main.py` and module handlers** is tightly bound to pyTelegramBotAPI polling callbacks and cannot run in Cloudflare Workers.
+2. **Persistence layer in `db.py`** relies on local `sqlite3` and filesystem paths (`/data/bot.db`), incompatible with Workers runtime constraints.
+3. **Long-running/blocking processing assumptions** in current bot flow need asynchronous HTTP-friendly orchestration (job status endpoints and webhooks where needed).
+4. **Authentication model** must expand from bot-user context and `X-API-Key` into mini app init data validation + website session/JWT boundaries.
+
+### What should be migrated first
+
+1. **Establish storage abstraction + Cloudflare-native adapters** (D1 + Durable Objects).
+2. **Introduce transport-agnostic service layer** for user profile, credits, GPT history, API token, assets metadata.
+3. **Stand up Workers HTTP API** for mini app + website + Telegram webhook ingress.
+4. **Migrate Telegram bot from polling to webhook delivery** with service calls instead of direct DB logic.
+5. **Backfill remaining feature modules** (image/video/tts/gpt advanced flows) into service layer incrementally.
+
+## Staged phases
+
+### Phase 0 (this change set)
+- Add Workers backend skeleton with shared API surface.
+- Add service layer contracts for profile/credits/history/token/feature entrypoints.
+- Add storage abstractions and initial D1/Durable Object usage points.
+- Add Telegram webhook + Mini App init-data validation entrypoints.
+
+### Phase 1
+- Port Python DB read/write call sites module-by-module into service layer methods.
+- Mirror existing user-visible bot responses for `/start`, profile, credit checks, GPT entrypoint.
+
+### Phase 2
+- Move generation workloads to provider adapters and async job model.
+- Add website auth/session boundary and admin/internal route separation.
+
+### Phase 3
+- Decommission polling process and local sqlite, cut over to webhook-only bot.
+- Run data migration from current sqlite exports into D1/DO stores.
+
+## Compatibility notes
+
+- This migration intentionally **does not attempt to run Python bot code inside Workers**.
+- User-visible behavior can be preserved for simple flows first; media-heavy and long-running features may temporarily return "processing" + status polling responses during phased migration.

--- a/workers-backend/migrations/0001_initial.sql
+++ b/workers-backend/migrations/0001_initial.sql
@@ -1,0 +1,40 @@
+CREATE TABLE IF NOT EXISTS users (
+  user_id INTEGER PRIMARY KEY,
+  username TEXT,
+  first_name TEXT,
+  lang TEXT DEFAULT 'fa',
+  banned INTEGER NOT NULL DEFAULT 0,
+  credits REAL NOT NULL DEFAULT 0,
+  joined_at INTEGER NOT NULL,
+  last_seen_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS api_tokens (
+  user_id INTEGER PRIMARY KEY REFERENCES users(user_id) ON DELETE CASCADE,
+  token TEXT NOT NULL UNIQUE,
+  created_at INTEGER NOT NULL,
+  rotated_at INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS gpt_messages (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+  role TEXT NOT NULL,
+  content TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS generated_assets (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+  asset_type TEXT NOT NULL,
+  source_prompt TEXT,
+  storage_url TEXT,
+  status TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_gpt_messages_user_created
+  ON gpt_messages(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_generated_assets_user_created
+  ON generated_assets(user_id, created_at DESC);

--- a/workers-backend/src/auth/telegram.ts
+++ b/workers-backend/src/auth/telegram.ts
@@ -1,0 +1,26 @@
+const enc = new TextEncoder();
+
+async function hmacSha256(key: ArrayBuffer | Uint8Array, data: string): Promise<ArrayBuffer> {
+  const cryptoKey = await crypto.subtle.importKey("raw", key, { name: "HMAC", hash: "SHA-256" }, false, ["sign"]);
+  return crypto.subtle.sign("HMAC", cryptoKey, enc.encode(data));
+}
+
+function hex(bytes: ArrayBuffer): string {
+  return [...new Uint8Array(bytes)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+export async function validateTelegramInitData(initData: string, botToken: string): Promise<boolean> {
+  const params = new URLSearchParams(initData);
+  const hash = params.get("hash");
+  if (!hash) return false;
+
+  params.delete("hash");
+  const dataCheckString = [...params.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([k, v]) => `${k}=${v}`)
+    .join("\n");
+
+  const secret = await crypto.subtle.digest("SHA-256", enc.encode(botToken));
+  const computed = hex(await hmacSha256(secret, dataCheckString));
+  return computed === hash;
+}

--- a/workers-backend/src/domain/types.ts
+++ b/workers-backend/src/domain/types.ts
@@ -1,0 +1,27 @@
+export type ClientType = "telegram_bot" | "telegram_mini_app" | "website";
+
+export interface UserProfile {
+  userId: number;
+  username: string | null;
+  firstName: string | null;
+  lang: string;
+  banned: boolean;
+  credits: number;
+  joinedAt: number;
+  lastSeenAt: number;
+}
+
+export interface AssetSummary {
+  id: number;
+  assetType: "image" | "video" | "audio";
+  sourcePrompt: string | null;
+  storageUrl: string | null;
+  status: "pending" | "ready" | "failed";
+  createdAt: number;
+}
+
+export interface GptMessage {
+  role: "user" | "assistant" | "system";
+  content: string;
+  createdAt: number;
+}

--- a/workers-backend/src/index.ts
+++ b/workers-backend/src/index.ts
@@ -1,0 +1,104 @@
+import { validateTelegramInitData } from "./auth/telegram";
+import { ApiTokenService, AssetService, GptHistoryService, UserService } from "./services/user-services";
+import { D1ApiTokenRepository, D1AssetRepository, D1GptHistoryRepository, D1UserRepository } from "./storage/d1-repositories";
+import { UserStateDO } from "./storage/user-state-do";
+import { handleTelegramWebhook } from "./telegram/webhook";
+
+export { UserStateDO };
+
+interface Env {
+  DB: D1Database;
+  USER_STATE: DurableObjectNamespace;
+  TELEGRAM_BOT_TOKEN: string;
+  TELEGRAM_WEBHOOK_SECRET: string;
+}
+
+const json = (data: unknown, status = 200) => new Response(JSON.stringify(data), { status, headers: { "content-type": "application/json" } });
+
+function bearerToken(req: Request): string | null {
+  const raw = req.headers.get("authorization") ?? "";
+  const [scheme, token] = raw.split(" ");
+  if (scheme?.toLowerCase() !== "bearer" || !token) return null;
+  return token.trim();
+}
+
+async function resolveAuthedUserId(req: Request, tokens: D1ApiTokenRepository): Promise<number | null> {
+  const token = bearerToken(req) ?? req.headers.get("x-api-key");
+  if (!token) return null;
+  return tokens.getUserIdByToken(token);
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+
+    const users = new D1UserRepository(env.DB);
+    const tokens = new D1ApiTokenRepository(env.DB);
+    const history = new D1GptHistoryRepository(env.DB);
+    const assets = new D1AssetRepository(env.DB);
+
+    const userService = new UserService(users);
+    const tokenService = new ApiTokenService(tokens);
+    const historyService = new GptHistoryService(history);
+    const assetService = new AssetService(assets);
+
+    // Telegram bot webhook transport
+    if (request.method === "POST" && url.pathname === `/telegram/webhook/${env.TELEGRAM_WEBHOOK_SECRET}`) {
+      const update = await request.json();
+      const result = await handleTelegramWebhook(update, { botToken: env.TELEGRAM_BOT_TOKEN, users });
+      return json(result);
+    }
+
+    // Telegram Mini App auth bootstrap
+    if (request.method === "POST" && url.pathname === "/miniapp/auth/telegram") {
+      const body = (await request.json()) as { initData?: string };
+      const initData = body.initData ?? "";
+      const valid = await validateTelegramInitData(initData, env.TELEGRAM_BOT_TOKEN);
+      if (!valid) return json({ error: "invalid_init_data" }, 401);
+      return json({ ok: true });
+    }
+
+    const authedUserId = await resolveAuthedUserId(request, tokens);
+
+    // Shared user profile for Mini App + Website
+    if (request.method === "GET" && url.pathname === "/v1/me") {
+      if (!authedUserId) return json({ error: "unauthorized" }, 401);
+      const profile = await userService.getProfile(authedUserId);
+      if (!profile) return json({ error: "not_found" }, 404);
+      return json(profile);
+    }
+
+    if (request.method === "POST" && url.pathname === "/v1/me/api-token/rotate") {
+      if (!authedUserId) return json({ error: "unauthorized" }, 401);
+      return json({ token: await tokenService.rotate(authedUserId) });
+    }
+
+    if (request.method === "GET" && url.pathname === "/v1/me/gpt-history") {
+      if (!authedUserId) return json({ error: "unauthorized" }, 401);
+      return json({ messages: await historyService.list(authedUserId, 50) });
+    }
+
+    if (request.method === "DELETE" && url.pathname === "/v1/me/gpt-history") {
+      if (!authedUserId) return json({ error: "unauthorized" }, 401);
+      await historyService.clear(authedUserId);
+      return json({ ok: true });
+    }
+
+    if (request.method === "GET" && url.pathname === "/v1/me/assets") {
+      if (!authedUserId) return json({ error: "unauthorized" }, 401);
+      return json({ items: await assetService.listUserAssets(authedUserId, 50) });
+    }
+
+    // Feature entrypoint discovery for Mini App/Website clients
+    if (request.method === "GET" && url.pathname === "/v1/features") {
+      return json({
+        gpt: { enabled: true, entrypoint: "/v1/gpt/chat" },
+        image: { enabled: true, entrypoint: "/v1/image" },
+        tts: { enabled: true, entrypoint: "/v1/tts" },
+        video: { enabled: true, entrypoint: "/v1/video" },
+      });
+    }
+
+    return new Response("Not Found", { status: 404 });
+  },
+};

--- a/workers-backend/src/services/user-services.ts
+++ b/workers-backend/src/services/user-services.ts
@@ -1,0 +1,52 @@
+import type { ApiTokenRepository, AssetRepository, GptHistoryRepository, UserRepository } from "../storage/contracts";
+
+export class UserService {
+  constructor(private users: UserRepository) {}
+
+  getProfile(userId: number) {
+    return this.users.getById(userId);
+  }
+}
+
+export class CreditService {
+  constructor(private users: UserRepository) {}
+
+  async charge(userId: number, amount: number) {
+    const profile = await this.users.getById(userId);
+    if (!profile) throw new Error("user_not_found");
+    if (profile.credits < amount) throw new Error("insufficient_credits");
+    await this.users.setCredits(userId, Number((profile.credits - amount).toFixed(2)));
+    return this.users.getById(userId);
+  }
+}
+
+export class ApiTokenService {
+  constructor(private tokens: ApiTokenRepository) {}
+
+  async getOrCreate(userId: number) {
+    const existing = await this.tokens.getByUserId(userId);
+    if (existing) return existing;
+    return this.tokens.rotate(userId);
+  }
+
+  rotate(userId: number) {
+    return this.tokens.rotate(userId);
+  }
+}
+
+export class GptHistoryService {
+  constructor(private history: GptHistoryRepository) {}
+  list(userId: number, limit = 20) {
+    return this.history.list(userId, limit);
+  }
+  clear(userId: number) {
+    return this.history.clear(userId);
+  }
+}
+
+export class AssetService {
+  constructor(private assets: AssetRepository) {}
+  listUserAssets(userId: number, limit = 20) {
+    return this.assets.listByUser(userId, limit);
+  }
+}

--- a/workers-backend/src/storage/contracts.ts
+++ b/workers-backend/src/storage/contracts.ts
@@ -1,0 +1,24 @@
+import type { AssetSummary, GptMessage, UserProfile } from "../domain/types";
+
+export interface UserRepository {
+  upsertTelegramUser(input: { userId: number; username?: string | null; firstName?: string | null }): Promise<UserProfile>;
+  getById(userId: number): Promise<UserProfile | null>;
+  touchLastSeen(userId: number): Promise<void>;
+  setCredits(userId: number, credits: number): Promise<void>;
+}
+
+export interface ApiTokenRepository {
+  getByUserId(userId: number): Promise<string | null>;
+  rotate(userId: number): Promise<string>;
+  getUserIdByToken(token: string): Promise<number | null>;
+}
+
+export interface GptHistoryRepository {
+  list(userId: number, limit: number): Promise<GptMessage[]>;
+  append(userId: number, role: GptMessage["role"], content: string): Promise<void>;
+  clear(userId: number): Promise<void>;
+}
+
+export interface AssetRepository {
+  listByUser(userId: number, limit: number): Promise<AssetSummary[]>;
+}

--- a/workers-backend/src/storage/d1-repositories.ts
+++ b/workers-backend/src/storage/d1-repositories.ts
@@ -1,0 +1,139 @@
+import type { AssetSummary, GptMessage, UserProfile } from "../domain/types";
+import type { ApiTokenRepository, AssetRepository, GptHistoryRepository, UserRepository } from "./contracts";
+
+const now = () => Math.floor(Date.now() / 1000);
+
+export class D1UserRepository implements UserRepository {
+  constructor(private db: D1Database) {}
+
+  async upsertTelegramUser(input: { userId: number; username?: string | null; firstName?: string | null }): Promise<UserProfile> {
+    const ts = now();
+    await this.db
+      .prepare(
+        `INSERT INTO users (user_id, username, first_name, joined_at, last_seen_at)
+         VALUES (?1, ?2, ?3, ?4, ?4)
+         ON CONFLICT(user_id) DO UPDATE SET
+           username = COALESCE(excluded.username, users.username),
+           first_name = COALESCE(excluded.first_name, users.first_name),
+           last_seen_at = excluded.last_seen_at`
+      )
+      .bind(input.userId, input.username ?? null, input.firstName ?? null, ts)
+      .run();
+
+    const profile = await this.getById(input.userId);
+    if (!profile) throw new Error("failed_to_upsert_user");
+    return profile;
+  }
+
+  async getById(userId: number): Promise<UserProfile | null> {
+    const row = await this.db
+      .prepare(`SELECT user_id, username, first_name, lang, banned, credits, joined_at, last_seen_at FROM users WHERE user_id = ?1`)
+      .bind(userId)
+      .first<any>();
+    if (!row) return null;
+    return {
+      userId: row.user_id,
+      username: row.username,
+      firstName: row.first_name,
+      lang: row.lang ?? "fa",
+      banned: !!row.banned,
+      credits: Number(row.credits ?? 0),
+      joinedAt: row.joined_at,
+      lastSeenAt: row.last_seen_at,
+    };
+  }
+
+  async touchLastSeen(userId: number): Promise<void> {
+    await this.db.prepare(`UPDATE users SET last_seen_at = ?1 WHERE user_id = ?2`).bind(now(), userId).run();
+  }
+
+  async setCredits(userId: number, credits: number): Promise<void> {
+    await this.db.prepare(`UPDATE users SET credits = ?1 WHERE user_id = ?2`).bind(credits, userId).run();
+  }
+}
+
+export class D1ApiTokenRepository implements ApiTokenRepository {
+  constructor(private db: D1Database) {}
+
+  async getByUserId(userId: number): Promise<string | null> {
+    const row = await this.db.prepare(`SELECT token FROM api_tokens WHERE user_id = ?1`).bind(userId).first<any>();
+    return row?.token ?? null;
+  }
+
+  async rotate(userId: number): Promise<string> {
+    const token = crypto.randomUUID().replace(/-/g, "") + crypto.randomUUID().replace(/-/g, "");
+    const ts = now();
+    await this.db
+      .prepare(
+        `INSERT INTO api_tokens (user_id, token, created_at, rotated_at)
+         VALUES (?1, ?2, ?3, NULL)
+         ON CONFLICT(user_id) DO UPDATE SET token = excluded.token, rotated_at = ?4`
+      )
+      .bind(userId, token, ts, ts)
+      .run();
+    return token;
+  }
+
+  async getUserIdByToken(token: string): Promise<number | null> {
+    const row = await this.db.prepare(`SELECT user_id FROM api_tokens WHERE token = ?1`).bind(token).first<any>();
+    return row?.user_id ?? null;
+  }
+}
+
+export class D1GptHistoryRepository implements GptHistoryRepository {
+  constructor(private db: D1Database) {}
+
+  async list(userId: number, limit: number): Promise<GptMessage[]> {
+    const { results } = await this.db
+      .prepare(
+        `SELECT role, content, created_at
+           FROM gpt_messages
+          WHERE user_id = ?1
+          ORDER BY created_at DESC
+          LIMIT ?2`
+      )
+      .bind(userId, limit)
+      .all<any>();
+
+    return (results ?? [])
+      .reverse()
+      .map((row) => ({ role: row.role, content: row.content, createdAt: row.created_at } as GptMessage));
+  }
+
+  async append(userId: number, role: GptMessage["role"], content: string): Promise<void> {
+    await this.db
+      .prepare(`INSERT INTO gpt_messages (user_id, role, content, created_at) VALUES (?1, ?2, ?3, ?4)`)
+      .bind(userId, role, content, now())
+      .run();
+  }
+
+  async clear(userId: number): Promise<void> {
+    await this.db.prepare(`DELETE FROM gpt_messages WHERE user_id = ?1`).bind(userId).run();
+  }
+}
+
+export class D1AssetRepository implements AssetRepository {
+  constructor(private db: D1Database) {}
+
+  async listByUser(userId: number, limit: number): Promise<AssetSummary[]> {
+    const { results } = await this.db
+      .prepare(
+        `SELECT id, asset_type, source_prompt, storage_url, status, created_at
+           FROM generated_assets
+          WHERE user_id = ?1
+          ORDER BY created_at DESC
+          LIMIT ?2`
+      )
+      .bind(userId, limit)
+      .all<any>();
+
+    return (results ?? []).map((row) => ({
+      id: row.id,
+      assetType: row.asset_type,
+      sourcePrompt: row.source_prompt,
+      storageUrl: row.storage_url,
+      status: row.status,
+      createdAt: row.created_at,
+    }));
+  }
+}

--- a/workers-backend/src/storage/user-state-do.ts
+++ b/workers-backend/src/storage/user-state-do.ts
@@ -1,0 +1,22 @@
+/**
+ * Per-user strongly consistent state.
+ * Intended for flows like in-progress Telegram conversation/session state.
+ */
+export class UserStateDO extends DurableObject {
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (request.method === "GET" && url.pathname === "/state") {
+      const state = (await this.ctx.storage.get<string>("state")) ?? "";
+      return Response.json({ state });
+    }
+
+    if (request.method === "PUT" && url.pathname === "/state") {
+      const body = (await request.json()) as { state?: string };
+      await this.ctx.storage.put("state", body.state ?? "");
+      return Response.json({ ok: true });
+    }
+
+    return new Response("Not Found", { status: 404 });
+  }
+}

--- a/workers-backend/src/telegram/webhook.ts
+++ b/workers-backend/src/telegram/webhook.ts
@@ -1,0 +1,35 @@
+import type { UserRepository } from "../storage/contracts";
+
+interface TelegramUpdate {
+  message?: {
+    text?: string;
+    from?: { id: number; username?: string; first_name?: string };
+    chat?: { id: number };
+  };
+}
+
+export async function handleTelegramWebhook(update: TelegramUpdate, deps: { botToken: string; users: UserRepository }) {
+  const message = update.message;
+  if (!message?.from || !message.chat) return { ok: true };
+
+  const user = await deps.users.upsertTelegramUser({
+    userId: message.from.id,
+    username: message.from.username,
+    firstName: message.from.first_name,
+  });
+
+  const text = (message.text ?? "").trim();
+  if (text === "/start") {
+    await sendTelegramMessage(deps.botToken, message.chat.id, `👋 Welcome ${user.firstName ?? ""}`.trim());
+  }
+
+  return { ok: true };
+}
+
+async function sendTelegramMessage(botToken: string, chatId: number, text: string) {
+  await fetch(`https://api.telegram.org/bot${botToken}/sendMessage`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ chat_id: chatId, text }),
+  });
+}

--- a/workers-backend/wrangler.toml
+++ b/workers-backend/wrangler.toml
@@ -1,0 +1,16 @@
+name = "vexa-shared-backend"
+main = "src/index.ts"
+compatibility_date = "2026-04-18"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "vexa"
+database_id = "REPLACE_WITH_D1_ID"
+
+[[durable_objects.bindings]]
+name = "USER_STATE"
+class_name = "UserStateDO"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["UserStateDO"]


### PR DESCRIPTION
### Motivation
- Begin a staged migration from the Python polling bot to a Cloudflare Workers HTTP-first shared backend so the Telegram bot (webhook), Telegram Mini App, and website can share services and storage.
- Replace local filesystem-bound `sqlite3` persistence with Cloudflare-native storage primitives (`D1` and `Durable Objects`) behind a storage abstraction so all transports use the same data layer.
- Separate transport concerns from business logic by introducing a service layer callable from webhook handlers and HTTP routes.
- Provide an incremental, non-breaking Phase‑0 scaffold so the legacy Python runtime can remain while features are ported.

### Description
- Added a migration plan and staged cutover notes in `docs/migration/staged-workers-migration.md` describing reuse vs rewrite and phased work items.
- Introduced a Workers project scaffold under `workers-backend/` including `wrangler.toml`, initial D1 migration SQL (`workers-backend/migrations/0001_initial.sql`), and domain types in `workers-backend/src/domain/types.ts`.
- Implemented storage abstractions (`workers-backend/src/storage/contracts.ts`) and D1-backed repository implementations (`workers-backend/src/storage/d1-repositories.ts`) for users, API tokens, GPT history, and generated assets metadata.
- Added a Durable Object for per-user strongly-consistent state at `workers-backend/src/storage/user-state-do.ts` and a small `UserService`/`CreditService`/`ApiTokenService`/`GptHistoryService`/`AssetService` layer in `workers-backend/src/services/user-services.ts`.
- Added Telegram-specific migration helpers including Mini App init-data verification in `workers-backend/src/auth/telegram.ts` and a minimal Telegram webhook handler at `workers-backend/src/telegram/webhook.ts` with a shared HTTP entrypoint router at `workers-backend/src/index.ts` exposing endpoints such as `POST /telegram/webhook/{secret}`, `POST /miniapp/auth/telegram`, `GET /v1/me`, `POST /v1/me/api-token/rotate`, `GET|DELETE /v1/me/gpt-history`, `GET /v1/me/assets`, and `GET /v1/features`.
- Updated `README.md` with a summary of the staged migration and current scaffold contents.

### Testing
- Ran Python syntax checks with `python -m py_compile main.py api_server.py db.py`, which completed successfully without syntax errors.
- The Workers TypeScript scaffold is static code added to the tree and includes D1 migration SQL and compile-time repository shape (no runtime Workers tests were executed in this change set).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e3e4dbe57c83319b054d14ad063106)