### PR TITLE
Migrate Vexa to Cloudflare Workers-first shared backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,89 +1,133 @@
-# vexa-ai
+# Vexa AI — Cloudflare-native shared platform
 
-## تنظیم و استفاده از GPT
+Vexa is now migrated to a **Cloudflare Workers-first architecture** with one shared backend for:
 
-برای فعال‌سازی دستیار GPT داخل ربات تلگرام متغیرهای محیطی زیر را مقداردهی کنید:
+1. Telegram Bot (webhook)
+2. Telegram Mini App
+3. Website clients
 
-- `GPT_API` یا `GPT_API_KEY` یا `OPENAI_API_KEY` — کلید دسترسی به سرویس GPT (الزامی).
-- `GPT_MODE` — نوع سرویس GPT؛ مقدار `assistant` از OpenAI Assistants/Responses استفاده می‌کند (پیش‌فرض `chat`).
-- `GPT_API_URL` — آدرس سرویس چت؛ برای حالت `assistant` به‌صورت پیش‌فرض `https://api.openai.com/v1/responses` است.
-- `GPT_MODEL` — نام مدل، پیش‌فرض `gpt-4o-mini`.
-- `GPT_API_TIMEOUT` — زمان انتظار درخواست بر حسب ثانیه، پیش‌فرض `45`.
-- `GPT_API_KEY_HEADER` و `GPT_API_KEY_PREFIX` — در صورت نیاز به هدر سفارشی برای کلید.
-- `GPT_SYSTEM_PROMPT` — پیام سیستمی برای شروع هر مکالمه (پیش‌فرض: «You are Vexa GPT-5…»).
-- `GPT_HISTORY_LIMIT` — تعداد پیام‌های اخیر که در هر پاسخ به GPT ارسال می‌شود (پیش‌فرض `6`).
-- `GPT_TEMPERATURE` — میزان خلاقیت پاسخ‌ها (۰ تا ۲، پیش‌فرض `0.7`).
-- `GPT_TOP_P` — مقدار `top_p` برای نمونه‌گیری هسته‌ای (۰ تا ۱، پیش‌فرض `1`).
-- `GPT_MAX_TOKENS` — سقف توکن برای هر پاسخ (۰ یعنی بدون محدودیت جداگانه).
-- `GPT_ASSISTANT_ID` — در صورت استفاده از Assistants API می‌توانید شناسه دستیار از پیش ساخته‌شده را وارد کنید (اختیاری). در صورت تنظیم نشدن این متغیر، مقدار `ASSISTANT_ID` (در Secrets) یا `OPENAI_ASSISTANT_ID` نیز به‌صورت خودکار خوانده می‌شود.
+The old Python polling stack (`main.py`, `api_server.py`, `db.py`) is retained only as **legacy reference** and is no longer the production target.
 
-در صورتی که بخواهید ربات از OpenAI Assistant/Responses استفاده کند، کافی است متغیر `GPT_MODE=assistant` را تنظیم کنید. در این حالت، پیام‌ها همانند قبل از تاریخچه محلی ساخته شده و به اندپوینت جدید (`/v1/responses`) ارسال می‌شوند و در صورت وجود `GPT_ASSISTANT_ID` همان دستیار از پیش ساخته‌شده اجرا خواهد شد.
+## Architecture
 
-## امکانات ربات
+- **Runtime:** Cloudflare Workers (`workers-backend/src/index.ts`)
+- **Persistence:** Cloudflare D1 (relational data)
+- **Strong per-user flow state:** Durable Object (`UserStateDO`)
+- **Auth:**
+  - Telegram Mini App `initData` verification + issued session token
+  - Bearer session token and per-user API token auth
+- **Shared services:** user profile, credits, API token lifecycle, GPT history, assets, feature discovery
 
-- دستور `/gpt` برای شروع گفت‌وگوی مستقیم با GPT در همان چت تلگرام. با دستور `/endgpt` می‌توانید مکالمه را پایان دهید و دکمه «شروع چت جدید ♻️» تاریخچه را پاک می‌کند.
-- در منوی اصلی، دکمه GPT شما را به گفت‌وگوی درون ربات هدایت می‌کند.
+## Implemented API routes
 
-پس از مقداردهی متغیرها، ربات آماده است تا پیام‌های کاربران را به سرویس GPT ارسال کرده و پاسخ را داخل تلگرام نمایش دهد.
+### Public routes
+- `GET /v1/health`
+- `GET /v1/features`
+- `GET /v1/telegram/webhook-info`
+- `POST /v1/auth/telegram-miniapp`
 
-## API خارجی برای تولید عکس و صدا
+### Authenticated routes
+- `GET /v1/me`
+- `GET /v1/me/credits`
+- `GET /v1/me/api-token`
+- `POST /v1/me/api-token/rotate`
+- `GET /v1/me/gpt-history`
+- `DELETE /v1/me/gpt-history`
+- `GET /v1/me/assets`
 
-هر کاربر می‌تواند از داخل منوی اصلی ربات، بخش «API Token» را باز کند و کلید اختصاصی خودش را ببیند یا تعویض کند. این کلید برای احراز هویت درخواست‌های HTTP استفاده می‌شود.
+### Telegram webhook route
+- `POST /telegram/webhook/<TELEGRAM_WEBHOOK_SECRET>`
 
-### نحوه اجرا
+Implemented bot commands:
+- `/start`
+- `/profile`
+- `/credits`
+- `/apitoken`
+- `/rotatetoken`
+- `/history`
+- `/resethistory`
+
+`callback_query` is now acknowledged and preserved as an extension point for future interactive flows.
+
+## Storage model (D1)
+
+Core tables in `workers-backend/migrations/0001_initial.sql`:
+
+- `users`
+- `api_tokens`
+- `user_sessions`
+- `gpt_messages`
+- `generated_assets`
+- `user_state`
+- `credit_ledger`
+- `feature_flags`
+
+## Local development
 
 ```bash
-uvicorn api_server:app --host 0.0.0.0 --port 8000
+cd workers-backend
+npm install
+npm run check
+npm run dev
 ```
 
-### احراز هویت
+## D1 setup
 
-در هر درخواست هدر زیر را ارسال کنید:
+1. Create database:
+   ```bash
+   wrangler d1 create vexa
+   ```
+2. Copy resulting `database_id` into `workers-backend/wrangler.toml`.
+3. Run migrations locally:
+   ```bash
+   npm run d1:migrate:local
+   ```
+4. Run migrations remotely:
+   ```bash
+   npm run d1:migrate:remote
+   ```
 
+## Durable Object setup
+
+`wrangler.toml` already binds `USER_STATE` and includes the class migration tag.
+Deploy once after migration to register it in your Worker.
+
+## Telegram webhook setup
+
+1. Deploy Worker and copy base URL.
+2. Set secrets:
+   ```bash
+   wrangler secret put TELEGRAM_BOT_TOKEN
+   wrangler secret put TELEGRAM_WEBHOOK_SECRET
+   ```
+3. Set webhook:
+   ```bash
+   curl "https://api.telegram.org/bot<TELEGRAM_BOT_TOKEN>/setWebhook?url=<WORKER_BASE_URL>/telegram/webhook/<TELEGRAM_WEBHOOK_SECRET>"
+   ```
+4. Verify:
+   ```bash
+   curl "https://api.telegram.org/bot<TELEGRAM_BOT_TOKEN>/getWebhookInfo"
+   ```
+
+## Telegram Mini App auth flow
+
+1. Mini App sends `initData` to `POST /v1/auth/telegram-miniapp`.
+2. Backend validates signature and `auth_date` freshness.
+3. Backend upserts user and issues a `Bearer` session token.
+4. Mini App uses `Authorization: Bearer <accessToken>` for `/v1/me*` APIs.
+
+## Production deploy
+
+```bash
+cd workers-backend
+npm install
+npm run check
+npm run d1:migrate:remote
+npm run deploy
 ```
-X-API-Key: <TOKEN>
-```
 
-### اندپوینت‌ها
+## Legacy status
 
-| متد | مسیر       | توضیح | هزینه |
-|-----|------------|-------|-------|
-| POST | `/v1/image` | تولید تصویر Vexa | ۵ کردیت |
-| POST | `/v1/tts`   | تبدیل متن به صدا (صداهای پیش‌فرض) | ۰٫۰۵ کردیت برای هر کاراکتر |
-| GET  | `/v1/voices` | فهرست صداهای قابل استفاده | ۰ |
-
-خروجی `POST /v1/image` لینک مستقیم تصویر است. خروجی `POST /v1/tts` شامل محتوای صوتی base64 و موجودی باقی‌ماندهٔ کاربر می‌شود. تمام هزینه‌ها از همان موجودی کردیت حساب تلگرام کسر خواهد شد.
-
----
-
-## Staged Cloudflare migration (new)
-
-A new Workers-based shared backend scaffold has been added under `workers-backend/`.
-
-### Why
-
-To support all three clients on one backend:
-1. Telegram bot (webhook)
-2. Telegram Mini App
-3. Website
-
-### What is included now
-
-- Worker entrypoint and route layout: `workers-backend/src/index.ts`
-- Storage abstraction and D1-backed repositories:
-  - `workers-backend/src/storage/contracts.ts`
-  - `workers-backend/src/storage/d1-repositories.ts`
-- Durable Object for per-user strongly consistent state:
-  - `workers-backend/src/storage/user-state-do.ts`
-- Telegram Mini App init data validation:
-  - `workers-backend/src/auth/telegram.ts`
-- Telegram webhook transport handler:
-  - `workers-backend/src/telegram/webhook.ts`
-- Initial D1 schema:
-  - `workers-backend/migrations/0001_initial.sql`
-- Migration phase notes:
-  - `docs/migration/staged-workers-migration.md`
-
-### Current status
-
-This is phase-0 scaffolding for a staged migration. The polling Python bot remains as legacy runtime until feature-by-feature cutover is complete.
+- Python polling bot is deprecated and not the active production architecture.
+- New production path is Cloudflare Workers + D1 + Durable Objects.
+- Legacy code is retained temporarily for behavior parity reference during final feature backfill.

--- a/docs/migration/staged-workers-migration.md
+++ b/docs/migration/staged-workers-migration.md
@@ -1,50 +1,49 @@
-# Staged migration plan: Python polling bot ➜ Cloudflare Workers shared backend
+# Migration status: Python polling stack ➜ Cloudflare Workers shared backend
 
-## Repository inspection summary
+## Completed cutover decisions
 
-### What can be reused
+- Primary backend runtime is now **Cloudflare Workers**.
+- Telegram bot transport is now **webhook-based** (no polling in the new architecture).
+- Shared APIs are now available for Telegram Mini App and Website clients.
+- D1 is now the persistent source of truth for shared entities.
+- Durable Object support is retained for strongly consistent per-user state workflows.
 
-1. **Feature-level domain behavior already exists** inside service modules such as image, TTS, clone, GPT, and video. The core business actions (e.g. credit charging, generation flow) are conceptually reusable if detached from TeleBot update objects.
-2. **Data model concepts in `db.py`** (users, credits, API tokens, GPT history, generated assets, cloned voices) are reusable as schema/contracts, even if the implementation must change.
-3. **Existing FastAPI endpoint design** in `api_server.py` can seed the HTTP-first API shape for all clients.
-4. **Localization text catalogs and feature flags** can be reused as part of service responses.
+## Shared domain concepts carried forward
 
-### What must be rewritten
+The Workers data model and services preserve these repository concepts:
 
-1. **Transport wiring in `main.py` and module handlers** is tightly bound to pyTelegramBotAPI polling callbacks and cannot run in Cloudflare Workers.
-2. **Persistence layer in `db.py`** relies on local `sqlite3` and filesystem paths (`/data/bot.db`), incompatible with Workers runtime constraints.
-3. **Long-running/blocking processing assumptions** in current bot flow need asynchronous HTTP-friendly orchestration (job status endpoints and webhooks where needed).
-4. **Authentication model** must expand from bot-user context and `X-API-Key` into mini app init data validation + website session/JWT boundaries.
+- users/profile + bootstrap from Telegram identity
+- credits/balance representation
+- API token lifecycle (read + rotate)
+- GPT history listing/reset
+- generated assets listing
+- feature discovery for clients
 
-### What should be migrated first
+## What is intentionally left as parity backlog
 
-1. **Establish storage abstraction + Cloudflare-native adapters** (D1 + Durable Objects).
-2. **Introduce transport-agnostic service layer** for user profile, credits, GPT history, API token, assets metadata.
-3. **Stand up Workers HTTP API** for mini app + website + Telegram webhook ingress.
-4. **Migrate Telegram bot from polling to webhook delivery** with service calls instead of direct DB logic.
-5. **Backfill remaining feature modules** (image/video/tts/gpt advanced flows) into service layer incrementally.
+The following advanced generation/provider workflows from legacy Python are not yet fully ported:
 
-## Staged phases
+- image/video/tts generation provider execution pipelines
+- referral/purchase/admin commands and economics edge cases
+- legacy module-specific conversational flows
 
-### Phase 0 (this change set)
-- Add Workers backend skeleton with shared API surface.
-- Add service layer contracts for profile/credits/history/token/feature entrypoints.
-- Add storage abstractions and initial D1/Durable Object usage points.
-- Add Telegram webhook + Mini App init-data validation entrypoints.
+These are now explicit backlog items and are no longer hidden behind scaffold routes.
 
-### Phase 1
-- Port Python DB read/write call sites module-by-module into service layer methods.
-- Mirror existing user-visible bot responses for `/start`, profile, credit checks, GPT entrypoint.
+## New backend route map (implemented)
 
-### Phase 2
-- Move generation workloads to provider adapters and async job model.
-- Add website auth/session boundary and admin/internal route separation.
+- `GET /v1/health`
+- `GET /v1/features`
+- `GET /v1/telegram/webhook-info`
+- `POST /v1/auth/telegram-miniapp`
+- `GET /v1/me`
+- `GET /v1/me/credits`
+- `GET /v1/me/api-token`
+- `POST /v1/me/api-token/rotate`
+- `GET /v1/me/gpt-history`
+- `DELETE /v1/me/gpt-history`
+- `GET /v1/me/assets`
+- `POST /telegram/webhook/<secret>`
 
-### Phase 3
-- Decommission polling process and local sqlite, cut over to webhook-only bot.
-- Run data migration from current sqlite exports into D1/DO stores.
+## Operational note
 
-## Compatibility notes
-
-- This migration intentionally **does not attempt to run Python bot code inside Workers**.
-- User-visible behavior can be preserved for simple flows first; media-heavy and long-running features may temporarily return "processing" + status polling responses during phased migration.
+Do not run `main.py` polling as primary production runtime after this migration stage. Python code is now legacy reference only.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,18 +1,8 @@
-pyTelegramBotAPI==4.14.0
-requests==2.31.0
-python-dotenv==1.0.0
-modules
-pytelegrambotapi
-pyTelegramBotAPI==4.14.0
-python-dotenv==1.0.0
-requests==2.31.0
-fastapi==0.111.0
-uvicorn[standard]==0.30.1
-pydub==0.25.1
-ffmpeg-python
-fastapi
-pydantic
+# Legacy-only Python dependencies.
+# This file is kept for reference during migration parity work.
+# Primary production runtime is now Cloudflare Workers (see workers-backend/).
+
 pyTelegramBotAPI
-python-dotenv
-requests
+fastapi
 uvicorn
+requests

--- a/workers-backend/migrations/0001_initial.sql
+++ b/workers-backend/migrations/0001_initial.sql
@@ -5,8 +5,12 @@ CREATE TABLE IF NOT EXISTS users (
   lang TEXT DEFAULT 'fa',
   banned INTEGER NOT NULL DEFAULT 0,
   credits REAL NOT NULL DEFAULT 0,
+  ref_code TEXT,
+  referred_by TEXT,
   joined_at INTEGER NOT NULL,
-  last_seen_at INTEGER NOT NULL
+  last_seen_at INTEGER NOT NULL,
+  onboarding_pending INTEGER NOT NULL DEFAULT 0,
+  welcome_sent_at INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS api_tokens (
@@ -14,6 +18,14 @@ CREATE TABLE IF NOT EXISTS api_tokens (
   token TEXT NOT NULL UNIQUE,
   created_at INTEGER NOT NULL,
   rotated_at INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS user_sessions (
+  session_token TEXT PRIMARY KEY,
+  user_id INTEGER NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+  client_type TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS gpt_messages (
@@ -31,10 +43,43 @@ CREATE TABLE IF NOT EXISTS generated_assets (
   source_prompt TEXT,
   storage_url TEXT,
   status TEXT NOT NULL,
+  provider TEXT,
   created_at INTEGER NOT NULL
 );
 
-CREATE INDEX IF NOT EXISTS idx_gpt_messages_user_created
-  ON gpt_messages(user_id, created_at DESC);
-CREATE INDEX IF NOT EXISTS idx_generated_assets_user_created
-  ON generated_assets(user_id, created_at DESC);
+CREATE TABLE IF NOT EXISTS user_state (
+  user_id INTEGER PRIMARY KEY REFERENCES users(user_id) ON DELETE CASCADE,
+  state_json TEXT NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS credit_ledger (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+  amount REAL NOT NULL,
+  reason TEXT NOT NULL,
+  source TEXT,
+  created_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS feature_flags (
+  feature_key TEXT PRIMARY KEY,
+  enabled INTEGER NOT NULL DEFAULT 1,
+  description TEXT,
+  updated_at INTEGER NOT NULL
+);
+
+INSERT OR IGNORE INTO feature_flags(feature_key, enabled, description, updated_at) VALUES
+('telegram_bot', 1, 'Telegram bot webhook transport', strftime('%s','now')),
+('telegram_mini_app', 1, 'Telegram Mini App client support', strftime('%s','now')),
+('website', 1, 'Website client support over shared APIs', strftime('%s','now')),
+('api_tokens', 1, 'Per-user API token lifecycle', strftime('%s','now')),
+('gpt_history', 1, 'GPT history fetch/reset APIs', strftime('%s','now')),
+('assets', 1, 'Generated assets list APIs', strftime('%s','now'));
+
+CREATE INDEX IF NOT EXISTS idx_api_tokens_token ON api_tokens(token);
+CREATE INDEX IF NOT EXISTS idx_sessions_user_expires ON user_sessions(user_id, expires_at DESC);
+CREATE INDEX IF NOT EXISTS idx_sessions_expires ON user_sessions(expires_at);
+CREATE INDEX IF NOT EXISTS idx_gpt_messages_user_created ON gpt_messages(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_generated_assets_user_created ON generated_assets(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_credit_ledger_user_created ON credit_ledger(user_id, created_at DESC);

--- a/workers-backend/package.json
+++ b/workers-backend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "vexa-workers-backend",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "check": "tsc --noEmit",
+    "d1:migrate:local": "wrangler d1 migrations apply vexa --local",
+    "d1:migrate:remote": "wrangler d1 migrations apply vexa --remote"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.3",
+    "wrangler": "^4.12.0",
+    "@cloudflare/workers-types": "^4.20260408.0"
+  }
+}

--- a/workers-backend/src/auth/telegram.ts
+++ b/workers-backend/src/auth/telegram.ts
@@ -1,6 +1,10 @@
-const enc = new TextEncoder();
+import { HttpError } from "../http/response";
+import type { TelegramMiniAppIdentity } from "../domain/types";
 
-async function hmacSha256(key: ArrayBuffer | Uint8Array, data: string): Promise<ArrayBuffer> {
+const enc = new TextEncoder();
+const MAX_AUTH_AGE_SECONDS = 24 * 60 * 60;
+
+async function hmacSha256Raw(key: ArrayBuffer | Uint8Array, data: string): Promise<ArrayBuffer> {
   const cryptoKey = await crypto.subtle.importKey("raw", key, { name: "HMAC", hash: "SHA-256" }, false, ["sign"]);
   return crypto.subtle.sign("HMAC", cryptoKey, enc.encode(data));
 }
@@ -9,10 +13,23 @@ function hex(bytes: ArrayBuffer): string {
   return [...new Uint8Array(bytes)].map((b) => b.toString(16).padStart(2, "0")).join("");
 }
 
-export async function validateTelegramInitData(initData: string, botToken: string): Promise<boolean> {
+function safeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let out = 0;
+  for (let i = 0; i < a.length; i++) out |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return out === 0;
+}
+
+export async function validateTelegramInitData(initData: string, botToken: string): Promise<TelegramMiniAppIdentity> {
   const params = new URLSearchParams(initData);
   const hash = params.get("hash");
-  if (!hash) return false;
+  if (!hash) throw new HttpError(401, "invalid_init_data", "Missing Telegram hash");
+
+  const authDate = Number(params.get("auth_date") || "0");
+  const now = Math.floor(Date.now() / 1000);
+  if (!authDate || authDate > now + 30 || now - authDate > MAX_AUTH_AGE_SECONDS) {
+    throw new HttpError(401, "stale_init_data", "Telegram init data is expired or invalid");
+  }
 
   params.delete("hash");
   const dataCheckString = [...params.entries()]
@@ -21,6 +38,27 @@ export async function validateTelegramInitData(initData: string, botToken: strin
     .join("\n");
 
   const secret = await crypto.subtle.digest("SHA-256", enc.encode(botToken));
-  const computed = hex(await hmacSha256(secret, dataCheckString));
-  return computed === hash;
+  const computed = hex(await hmacSha256Raw(secret, dataCheckString));
+  if (!safeEqual(computed, hash)) {
+    throw new HttpError(401, "invalid_init_data", "Telegram init data signature mismatch");
+  }
+
+  const userRaw = params.get("user");
+  if (!userRaw) throw new HttpError(401, "invalid_init_data", "Telegram user payload missing");
+
+  let user: any;
+  try {
+    user = JSON.parse(userRaw);
+  } catch {
+    throw new HttpError(401, "invalid_init_data", "Telegram user payload invalid JSON");
+  }
+
+  if (!user?.id) throw new HttpError(401, "invalid_init_data", "Telegram user id missing");
+
+  return {
+    telegramUserId: Number(user.id),
+    username: user.username ?? null,
+    firstName: user.first_name ?? null,
+    authDate,
+  };
 }

--- a/workers-backend/src/domain/types.ts
+++ b/workers-backend/src/domain/types.ts
@@ -13,7 +13,8 @@ export interface UserProfile {
 
 export interface AssetSummary {
   id: number;
-  assetType: "image" | "video" | "audio";
+  userId: number;
+  assetType: "image" | "video" | "audio" | "other";
   sourcePrompt: string | null;
   storageUrl: string | null;
   status: "pending" | "ready" | "failed";
@@ -21,7 +22,29 @@ export interface AssetSummary {
 }
 
 export interface GptMessage {
+  id?: number;
   role: "user" | "assistant" | "system";
   content: string;
   createdAt: number;
+}
+
+export interface FeatureFlag {
+  key: string;
+  enabled: boolean;
+  description: string;
+}
+
+export interface SessionRecord {
+  sessionToken: string;
+  userId: number;
+  clientType: ClientType;
+  createdAt: number;
+  expiresAt: number;
+}
+
+export interface TelegramMiniAppIdentity {
+  telegramUserId: number;
+  username?: string | null;
+  firstName?: string | null;
+  authDate: number;
 }

--- a/workers-backend/src/http/auth.ts
+++ b/workers-backend/src/http/auth.ts
@@ -1,0 +1,31 @@
+import { HttpError } from "./response";
+import type { Services } from "../routes/types";
+
+function bearerToken(req: Request): string | null {
+  const raw = req.headers.get("authorization") ?? "";
+  const [scheme, token] = raw.split(" ");
+  if (scheme?.toLowerCase() !== "bearer" || !token) return null;
+  return token.trim();
+}
+
+export async function resolveAuthedUserId(req: Request, services: Services): Promise<number | null> {
+  const bearer = bearerToken(req);
+  if (bearer) {
+    const session = await services.sessions.getByToken(bearer);
+    if (session) return session.userId;
+
+    const apiTokenUserId = await services.tokens.resolveTokenToUser(bearer);
+    if (apiTokenUserId) return apiTokenUserId;
+  }
+
+  const apiKey = req.headers.get("x-api-key")?.trim();
+  if (apiKey) return services.tokens.resolveTokenToUser(apiKey);
+
+  return null;
+}
+
+export async function requireAuthedUserId(req: Request, services: Services): Promise<number> {
+  const userId = await resolveAuthedUserId(req, services);
+  if (!userId) throw new HttpError(401, "unauthorized", "Missing or invalid authentication token");
+  return userId;
+}

--- a/workers-backend/src/http/cors.ts
+++ b/workers-backend/src/http/cors.ts
@@ -1,0 +1,24 @@
+const DEFAULT_ALLOWED_HEADERS = ["authorization", "content-type", "x-api-key"];
+
+export function withCors(request: Request, response: Response): Response {
+  const origin = request.headers.get("origin");
+  const headers = new Headers(response.headers);
+
+  if (origin) {
+    headers.set("access-control-allow-origin", origin);
+    headers.set("vary", "Origin");
+  } else {
+    headers.set("access-control-allow-origin", "*");
+  }
+
+  headers.set("access-control-allow-methods", "GET,POST,PUT,DELETE,OPTIONS");
+  headers.set("access-control-allow-headers", DEFAULT_ALLOWED_HEADERS.join(","));
+  headers.set("access-control-max-age", "86400");
+
+  return new Response(response.body, { status: response.status, headers });
+}
+
+export function handleCorsPreflight(request: Request): Response | null {
+  if (request.method !== "OPTIONS") return null;
+  return withCors(request, new Response(null, { status: 204 }));
+}

--- a/workers-backend/src/http/response.ts
+++ b/workers-backend/src/http/response.ts
@@ -1,0 +1,71 @@
+export interface ApiOk<T> {
+  ok: true;
+  data: T;
+}
+
+export interface ApiErr {
+  ok: false;
+  error: {
+    code: string;
+    message: string;
+    details?: unknown;
+  };
+}
+
+export class HttpError extends Error {
+  constructor(
+    public status: number,
+    public code: string,
+    message: string,
+    public details?: unknown
+  ) {
+    super(message);
+  }
+}
+
+export function jsonOk<T>(data: T, status = 200, headers: HeadersInit = {}): Response {
+  return new Response(JSON.stringify({ ok: true, data } satisfies ApiOk<T>), {
+    status,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      ...headers,
+    },
+  });
+}
+
+export function jsonError(err: unknown, fallbackMessage = "Internal Server Error"): Response {
+  if (err instanceof HttpError) {
+    return new Response(
+      JSON.stringify({
+        ok: false,
+        error: {
+          code: err.code,
+          message: err.message,
+          details: err.details,
+        },
+      } satisfies ApiErr),
+      {
+        status: err.status,
+        headers: { "content-type": "application/json; charset=utf-8" },
+      }
+    );
+  }
+
+  return new Response(
+    JSON.stringify({
+      ok: false,
+      error: {
+        code: "internal_error",
+        message: fallbackMessage,
+      },
+    } satisfies ApiErr),
+    {
+      status: 500,
+      headers: { "content-type": "application/json; charset=utf-8" },
+    }
+  );
+}
+
+export function parseJsonBody<T>(request: Request): Promise<T> {
+  return request.json<T>();
+}

--- a/workers-backend/src/index.ts
+++ b/workers-backend/src/index.ts
@@ -1,104 +1,44 @@
-import { validateTelegramInitData } from "./auth/telegram";
-import { ApiTokenService, AssetService, GptHistoryService, UserService } from "./services/user-services";
-import { D1ApiTokenRepository, D1AssetRepository, D1GptHistoryRepository, D1UserRepository } from "./storage/d1-repositories";
+import { withCors, handleCorsPreflight } from "./http/cors";
+import { jsonError, HttpError } from "./http/response";
+import { AssetService, ApiTokenService, CreditService, FeatureService, GptHistoryService, SessionService, UserService } from "./services/user-services";
+import { D1ApiTokenRepository, D1AssetRepository, D1FeatureRepository, D1GptHistoryRepository, D1SessionRepository, D1UserRepository } from "./storage/d1-repositories";
 import { UserStateDO } from "./storage/user-state-do";
-import { handleTelegramWebhook } from "./telegram/webhook";
+import { handleMeRoutes } from "./routes/me-routes";
+import { handlePublicRoutes } from "./routes/public-routes";
+import { handleTelegramRoutes } from "./routes/telegram-routes";
+import type { Env } from "./routes/types";
 
 export { UserStateDO };
 
-interface Env {
-  DB: D1Database;
-  USER_STATE: DurableObjectNamespace;
-  TELEGRAM_BOT_TOKEN: string;
-  TELEGRAM_WEBHOOK_SECRET: string;
-}
-
-const json = (data: unknown, status = 200) => new Response(JSON.stringify(data), { status, headers: { "content-type": "application/json" } });
-
-function bearerToken(req: Request): string | null {
-  const raw = req.headers.get("authorization") ?? "";
-  const [scheme, token] = raw.split(" ");
-  if (scheme?.toLowerCase() !== "bearer" || !token) return null;
-  return token.trim();
-}
-
-async function resolveAuthedUserId(req: Request, tokens: D1ApiTokenRepository): Promise<number | null> {
-  const token = bearerToken(req) ?? req.headers.get("x-api-key");
-  if (!token) return null;
-  return tokens.getUserIdByToken(token);
-}
-
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
+    const preflight = handleCorsPreflight(request);
+    if (preflight) return preflight;
+
     const url = new URL(request.url);
 
-    const users = new D1UserRepository(env.DB);
-    const tokens = new D1ApiTokenRepository(env.DB);
-    const history = new D1GptHistoryRepository(env.DB);
-    const assets = new D1AssetRepository(env.DB);
+    const services = {
+      users: new UserService(new D1UserRepository(env.DB)),
+      credits: new CreditService(new D1UserRepository(env.DB)),
+      tokens: new ApiTokenService(new D1ApiTokenRepository(env.DB)),
+      sessions: new SessionService(new D1SessionRepository(env.DB)),
+      history: new GptHistoryService(new D1GptHistoryRepository(env.DB)),
+      assets: new AssetService(new D1AssetRepository(env.DB)),
+      features: new FeatureService(new D1FeatureRepository(env.DB)),
+    };
 
-    const userService = new UserService(users);
-    const tokenService = new ApiTokenService(tokens);
-    const historyService = new GptHistoryService(history);
-    const assetService = new AssetService(assets);
+    try {
+      const ctx = { env, request, url, services };
 
-    // Telegram bot webhook transport
-    if (request.method === "POST" && url.pathname === `/telegram/webhook/${env.TELEGRAM_WEBHOOK_SECRET}`) {
-      const update = await request.json();
-      const result = await handleTelegramWebhook(update, { botToken: env.TELEGRAM_BOT_TOKEN, users });
-      return json(result);
+      const handlers = [handleTelegramRoutes, handlePublicRoutes, handleMeRoutes];
+      for (const handler of handlers) {
+        const response = await handler(ctx);
+        if (response) return withCors(request, response);
+      }
+
+      throw new HttpError(404, "not_found", `Route not found: ${request.method} ${url.pathname}`);
+    } catch (error) {
+      return withCors(request, jsonError(error));
     }
-
-    // Telegram Mini App auth bootstrap
-    if (request.method === "POST" && url.pathname === "/miniapp/auth/telegram") {
-      const body = (await request.json()) as { initData?: string };
-      const initData = body.initData ?? "";
-      const valid = await validateTelegramInitData(initData, env.TELEGRAM_BOT_TOKEN);
-      if (!valid) return json({ error: "invalid_init_data" }, 401);
-      return json({ ok: true });
-    }
-
-    const authedUserId = await resolveAuthedUserId(request, tokens);
-
-    // Shared user profile for Mini App + Website
-    if (request.method === "GET" && url.pathname === "/v1/me") {
-      if (!authedUserId) return json({ error: "unauthorized" }, 401);
-      const profile = await userService.getProfile(authedUserId);
-      if (!profile) return json({ error: "not_found" }, 404);
-      return json(profile);
-    }
-
-    if (request.method === "POST" && url.pathname === "/v1/me/api-token/rotate") {
-      if (!authedUserId) return json({ error: "unauthorized" }, 401);
-      return json({ token: await tokenService.rotate(authedUserId) });
-    }
-
-    if (request.method === "GET" && url.pathname === "/v1/me/gpt-history") {
-      if (!authedUserId) return json({ error: "unauthorized" }, 401);
-      return json({ messages: await historyService.list(authedUserId, 50) });
-    }
-
-    if (request.method === "DELETE" && url.pathname === "/v1/me/gpt-history") {
-      if (!authedUserId) return json({ error: "unauthorized" }, 401);
-      await historyService.clear(authedUserId);
-      return json({ ok: true });
-    }
-
-    if (request.method === "GET" && url.pathname === "/v1/me/assets") {
-      if (!authedUserId) return json({ error: "unauthorized" }, 401);
-      return json({ items: await assetService.listUserAssets(authedUserId, 50) });
-    }
-
-    // Feature entrypoint discovery for Mini App/Website clients
-    if (request.method === "GET" && url.pathname === "/v1/features") {
-      return json({
-        gpt: { enabled: true, entrypoint: "/v1/gpt/chat" },
-        image: { enabled: true, entrypoint: "/v1/image" },
-        tts: { enabled: true, entrypoint: "/v1/tts" },
-        video: { enabled: true, entrypoint: "/v1/video" },
-      });
-    }
-
-    return new Response("Not Found", { status: 404 });
   },
 };

--- a/workers-backend/src/routes/me-routes.ts
+++ b/workers-backend/src/routes/me-routes.ts
@@ -1,0 +1,44 @@
+import { requireAuthedUserId } from "../http/auth";
+import { jsonOk } from "../http/response";
+import type { RouteCtx } from "./types";
+
+export async function handleMeRoutes(ctx: RouteCtx): Promise<Response | null> {
+  const { request, url, services } = ctx;
+
+  if (!url.pathname.startsWith("/v1/me")) return null;
+
+  const userId = await requireAuthedUserId(request, services);
+
+  if (request.method === "GET" && url.pathname === "/v1/me") {
+    return jsonOk(await services.users.getProfile(userId));
+  }
+
+  if (request.method === "GET" && url.pathname === "/v1/me/credits") {
+    return jsonOk(await services.credits.getCredits(userId));
+  }
+
+  if (request.method === "GET" && url.pathname === "/v1/me/api-token") {
+    const token = await services.tokens.getOrCreate(userId);
+    return jsonOk({ token });
+  }
+
+  if (request.method === "POST" && url.pathname === "/v1/me/api-token/rotate") {
+    const token = await services.tokens.rotate(userId);
+    return jsonOk({ token });
+  }
+
+  if (request.method === "GET" && url.pathname === "/v1/me/gpt-history") {
+    return jsonOk({ messages: await services.history.list(userId, 100) });
+  }
+
+  if (request.method === "DELETE" && url.pathname === "/v1/me/gpt-history") {
+    await services.history.clear(userId);
+    return jsonOk({ cleared: true });
+  }
+
+  if (request.method === "GET" && url.pathname === "/v1/me/assets") {
+    return jsonOk({ items: await services.assets.listUserAssets(userId, 100) });
+  }
+
+  return null;
+}

--- a/workers-backend/src/routes/public-routes.ts
+++ b/workers-backend/src/routes/public-routes.ts
@@ -1,0 +1,62 @@
+import { validateTelegramInitData } from "../auth/telegram";
+import { jsonOk, parseJsonBody } from "../http/response";
+import type { RouteCtx } from "./types";
+
+export async function handlePublicRoutes(ctx: RouteCtx): Promise<Response | null> {
+  const { request, url, services, env } = ctx;
+
+  if (request.method === "GET" && url.pathname === "/v1/health") {
+    return jsonOk({ status: "ok", runtime: "cloudflare-workers" });
+  }
+
+  if (request.method === "GET" && url.pathname === "/v1/features") {
+    const flags = await services.features.list();
+    return jsonOk({
+      features: flags,
+      entrypoints: {
+        authTelegramMiniApp: "/v1/auth/telegram-miniapp",
+        me: "/v1/me",
+        credits: "/v1/me/credits",
+        apiToken: "/v1/me/api-token",
+        rotateApiToken: "/v1/me/api-token/rotate",
+        gptHistory: "/v1/me/gpt-history",
+        assets: "/v1/me/assets",
+      },
+    });
+  }
+
+  if (request.method === "GET" && url.pathname === "/v1/telegram/webhook-info") {
+    return jsonOk({
+      webhookPath: `/telegram/webhook/${env.TELEGRAM_WEBHOOK_SECRET}`,
+      setWebhookExample: `https://api.telegram.org/bot<TELEGRAM_BOT_TOKEN>/setWebhook?url=<WORKER_BASE_URL>/telegram/webhook/${env.TELEGRAM_WEBHOOK_SECRET}`,
+      notes: [
+        "Use the exact TELEGRAM_WEBHOOK_SECRET value from Worker env.",
+        "Do not run polling in production.",
+      ],
+    });
+  }
+
+  if (request.method === "POST" && url.pathname === "/v1/auth/telegram-miniapp") {
+    const body = await parseJsonBody<{ initData?: string }>(request);
+    const identity = await validateTelegramInitData(body.initData ?? "", env.TELEGRAM_BOT_TOKEN);
+
+    await services.users.bootstrapTelegramUser({
+      userId: identity.telegramUserId,
+      username: identity.username,
+      firstName: identity.firstName,
+    });
+
+    const ttlSeconds = Number(env.SESSION_TTL_SECONDS ?? "2592000");
+    const session = await services.sessions.createSession(identity.telegramUserId, "telegram_mini_app", ttlSeconds);
+    const profile = await services.users.getProfile(identity.telegramUserId);
+
+    return jsonOk({
+      accessToken: session.sessionToken,
+      tokenType: "Bearer",
+      expiresAt: session.expiresAt,
+      profile,
+    });
+  }
+
+  return null;
+}

--- a/workers-backend/src/routes/telegram-routes.ts
+++ b/workers-backend/src/routes/telegram-routes.ts
@@ -1,0 +1,25 @@
+import { HttpError, jsonOk, parseJsonBody } from "../http/response";
+import { handleTelegramWebhook } from "../telegram/webhook";
+import type { RouteCtx } from "./types";
+
+export async function handleTelegramRoutes(ctx: RouteCtx): Promise<Response | null> {
+  const { request, url, env, services } = ctx;
+
+  if (request.method === "POST" && url.pathname === `/telegram/webhook/${env.TELEGRAM_WEBHOOK_SECRET}`) {
+    const update = await parseJsonBody<any>(request);
+    const result = await handleTelegramWebhook(update, {
+      botToken: env.TELEGRAM_BOT_TOKEN,
+      users: services.users,
+      credits: services.credits,
+      tokens: services.tokens,
+      history: services.history,
+    });
+    return jsonOk(result);
+  }
+
+  if (request.method === "POST" && url.pathname.startsWith("/telegram/webhook/")) {
+    throw new HttpError(403, "forbidden", "Invalid webhook secret");
+  }
+
+  return null;
+}

--- a/workers-backend/src/routes/types.ts
+++ b/workers-backend/src/routes/types.ts
@@ -1,0 +1,26 @@
+import type { ApiTokenService, AssetService, CreditService, FeatureService, GptHistoryService, SessionService, UserService } from "../services/user-services";
+
+export interface Env {
+  DB: D1Database;
+  USER_STATE: DurableObjectNamespace;
+  TELEGRAM_BOT_TOKEN: string;
+  TELEGRAM_WEBHOOK_SECRET: string;
+  SESSION_TTL_SECONDS?: string;
+}
+
+export interface Services {
+  users: UserService;
+  credits: CreditService;
+  tokens: ApiTokenService;
+  sessions: SessionService;
+  history: GptHistoryService;
+  assets: AssetService;
+  features: FeatureService;
+}
+
+export interface RouteCtx {
+  env: Env;
+  request: Request;
+  url: URL;
+  services: Services;
+}

--- a/workers-backend/src/services/user-services.ts
+++ b/workers-backend/src/services/user-services.ts
@@ -1,22 +1,28 @@
-import type { ApiTokenRepository, AssetRepository, GptHistoryRepository, UserRepository } from "../storage/contracts";
+import type { ClientType } from "../domain/types";
+import { HttpError } from "../http/response";
+import type { ApiTokenRepository, AssetRepository, FeatureRepository, GptHistoryRepository, SessionRepository, UserRepository } from "../storage/contracts";
 
 export class UserService {
   constructor(private users: UserRepository) {}
 
-  getProfile(userId: number) {
-    return this.users.getById(userId);
+  async getProfile(userId: number) {
+    const profile = await this.users.getById(userId);
+    if (!profile) throw new HttpError(404, "not_found", "User profile not found");
+    return profile;
+  }
+
+  async bootstrapTelegramUser(input: { userId: number; username?: string | null; firstName?: string | null }) {
+    return this.users.upsertTelegramUser(input);
   }
 }
 
 export class CreditService {
   constructor(private users: UserRepository) {}
 
-  async charge(userId: number, amount: number) {
+  async getCredits(userId: number) {
     const profile = await this.users.getById(userId);
-    if (!profile) throw new Error("user_not_found");
-    if (profile.credits < amount) throw new Error("insufficient_credits");
-    await this.users.setCredits(userId, Number((profile.credits - amount).toFixed(2)));
-    return this.users.getById(userId);
+    if (!profile) throw new HttpError(404, "not_found", "User not found");
+    return { credits: profile.credits };
   }
 }
 
@@ -31,6 +37,26 @@ export class ApiTokenService {
 
   rotate(userId: number) {
     return this.tokens.rotate(userId);
+  }
+
+  async resolveTokenToUser(token: string) {
+    return this.tokens.getUserIdByToken(token);
+  }
+}
+
+export class SessionService {
+  constructor(private sessions: SessionRepository) {}
+
+  createSession(userId: number, clientType: ClientType, ttlSeconds: number) {
+    return this.sessions.create({ userId, clientType, ttlSeconds });
+  }
+
+  getByToken(token: string) {
+    return this.sessions.getByToken(token);
+  }
+
+  revoke(token: string) {
+    return this.sessions.revoke(token);
   }
 }
 
@@ -48,5 +74,13 @@ export class AssetService {
   constructor(private assets: AssetRepository) {}
   listUserAssets(userId: number, limit = 20) {
     return this.assets.listByUser(userId, limit);
+  }
+}
+
+export class FeatureService {
+  constructor(private features: FeatureRepository) {}
+
+  list() {
+    return this.features.list();
   }
 }

--- a/workers-backend/src/storage/contracts.ts
+++ b/workers-backend/src/storage/contracts.ts
@@ -1,4 +1,4 @@
-import type { AssetSummary, GptMessage, UserProfile } from "../domain/types";
+import type { AssetSummary, ClientType, FeatureFlag, GptMessage, SessionRecord, UserProfile } from "../domain/types";
 
 export interface UserRepository {
   upsertTelegramUser(input: { userId: number; username?: string | null; firstName?: string | null }): Promise<UserProfile>;
@@ -13,6 +13,12 @@ export interface ApiTokenRepository {
   getUserIdByToken(token: string): Promise<number | null>;
 }
 
+export interface SessionRepository {
+  create(input: { userId: number; clientType: ClientType; ttlSeconds: number }): Promise<SessionRecord>;
+  getByToken(token: string): Promise<SessionRecord | null>;
+  revoke(token: string): Promise<void>;
+}
+
 export interface GptHistoryRepository {
   list(userId: number, limit: number): Promise<GptMessage[]>;
   append(userId: number, role: GptMessage["role"], content: string): Promise<void>;
@@ -21,4 +27,8 @@ export interface GptHistoryRepository {
 
 export interface AssetRepository {
   listByUser(userId: number, limit: number): Promise<AssetSummary[]>;
+}
+
+export interface FeatureRepository {
+  list(): Promise<FeatureFlag[]>;
 }

--- a/workers-backend/src/storage/d1-repositories.ts
+++ b/workers-backend/src/storage/d1-repositories.ts
@@ -1,5 +1,5 @@
-import type { AssetSummary, GptMessage, UserProfile } from "../domain/types";
-import type { ApiTokenRepository, AssetRepository, GptHistoryRepository, UserRepository } from "./contracts";
+import type { AssetSummary, ClientType, FeatureFlag, GptMessage, SessionRecord, UserProfile } from "../domain/types";
+import type { ApiTokenRepository, AssetRepository, FeatureRepository, GptHistoryRepository, SessionRepository, UserRepository } from "./contracts";
 
 const now = () => Math.floor(Date.now() / 1000);
 
@@ -10,8 +10,8 @@ export class D1UserRepository implements UserRepository {
     const ts = now();
     await this.db
       .prepare(
-        `INSERT INTO users (user_id, username, first_name, joined_at, last_seen_at)
-         VALUES (?1, ?2, ?3, ?4, ?4)
+        `INSERT INTO users (user_id, username, first_name, lang, banned, credits, joined_at, last_seen_at)
+         VALUES (?1, ?2, ?3, 'fa', 0, 0, ?4, ?4)
          ON CONFLICT(user_id) DO UPDATE SET
            username = COALESCE(excluded.username, users.username),
            first_name = COALESCE(excluded.first_name, users.first_name),
@@ -30,6 +30,7 @@ export class D1UserRepository implements UserRepository {
       .prepare(`SELECT user_id, username, first_name, lang, banned, credits, joined_at, last_seen_at FROM users WHERE user_id = ?1`)
       .bind(userId)
       .first<any>();
+
     if (!row) return null;
     return {
       userId: row.user_id,
@@ -38,8 +39,8 @@ export class D1UserRepository implements UserRepository {
       lang: row.lang ?? "fa",
       banned: !!row.banned,
       credits: Number(row.credits ?? 0),
-      joinedAt: row.joined_at,
-      lastSeenAt: row.last_seen_at,
+      joinedAt: Number(row.joined_at),
+      lastSeenAt: Number(row.last_seen_at),
     };
   }
 
@@ -76,7 +77,47 @@ export class D1ApiTokenRepository implements ApiTokenRepository {
 
   async getUserIdByToken(token: string): Promise<number | null> {
     const row = await this.db.prepare(`SELECT user_id FROM api_tokens WHERE token = ?1`).bind(token).first<any>();
-    return row?.user_id ?? null;
+    return row ? Number(row.user_id) : null;
+  }
+}
+
+export class D1SessionRepository implements SessionRepository {
+  constructor(private db: D1Database) {}
+
+  async create(input: { userId: number; clientType: ClientType; ttlSeconds: number }): Promise<SessionRecord> {
+    const sessionToken = crypto.randomUUID().replace(/-/g, "") + crypto.randomUUID().replace(/-/g, "");
+    const createdAt = now();
+    const expiresAt = createdAt + input.ttlSeconds;
+    await this.db
+      .prepare(`INSERT INTO user_sessions(session_token, user_id, client_type, created_at, expires_at) VALUES(?1, ?2, ?3, ?4, ?5)`)
+      .bind(sessionToken, input.userId, input.clientType, createdAt, expiresAt)
+      .run();
+    return { sessionToken, userId: input.userId, clientType: input.clientType, createdAt, expiresAt };
+  }
+
+  async getByToken(token: string): Promise<SessionRecord | null> {
+    const row = await this.db
+      .prepare(`SELECT session_token, user_id, client_type, created_at, expires_at FROM user_sessions WHERE session_token = ?1 LIMIT 1`)
+      .bind(token)
+      .first<any>();
+
+    if (!row) return null;
+    if (Number(row.expires_at) <= now()) {
+      await this.revoke(token);
+      return null;
+    }
+
+    return {
+      sessionToken: row.session_token,
+      userId: Number(row.user_id),
+      clientType: row.client_type,
+      createdAt: Number(row.created_at),
+      expiresAt: Number(row.expires_at),
+    };
+  }
+
+  async revoke(token: string): Promise<void> {
+    await this.db.prepare(`DELETE FROM user_sessions WHERE session_token = ?1`).bind(token).run();
   }
 }
 
@@ -86,7 +127,7 @@ export class D1GptHistoryRepository implements GptHistoryRepository {
   async list(userId: number, limit: number): Promise<GptMessage[]> {
     const { results } = await this.db
       .prepare(
-        `SELECT role, content, created_at
+        `SELECT id, role, content, created_at
            FROM gpt_messages
           WHERE user_id = ?1
           ORDER BY created_at DESC
@@ -95,9 +136,7 @@ export class D1GptHistoryRepository implements GptHistoryRepository {
       .bind(userId, limit)
       .all<any>();
 
-    return (results ?? [])
-      .reverse()
-      .map((row) => ({ role: row.role, content: row.content, createdAt: row.created_at } as GptMessage));
+    return (results ?? []).reverse().map((row) => ({ id: Number(row.id), role: row.role, content: row.content, createdAt: Number(row.created_at) }));
   }
 
   async append(userId: number, role: GptMessage["role"], content: string): Promise<void> {
@@ -118,7 +157,7 @@ export class D1AssetRepository implements AssetRepository {
   async listByUser(userId: number, limit: number): Promise<AssetSummary[]> {
     const { results } = await this.db
       .prepare(
-        `SELECT id, asset_type, source_prompt, storage_url, status, created_at
+        `SELECT id, user_id, asset_type, source_prompt, storage_url, status, created_at
            FROM generated_assets
           WHERE user_id = ?1
           ORDER BY created_at DESC
@@ -128,12 +167,29 @@ export class D1AssetRepository implements AssetRepository {
       .all<any>();
 
     return (results ?? []).map((row) => ({
-      id: row.id,
+      id: Number(row.id),
+      userId: Number(row.user_id),
       assetType: row.asset_type,
       sourcePrompt: row.source_prompt,
       storageUrl: row.storage_url,
       status: row.status,
-      createdAt: row.created_at,
+      createdAt: Number(row.created_at),
+    }));
+  }
+}
+
+export class D1FeatureRepository implements FeatureRepository {
+  constructor(private db: D1Database) {}
+
+  async list(): Promise<FeatureFlag[]> {
+    const { results } = await this.db
+      .prepare(`SELECT feature_key, enabled, description FROM feature_flags ORDER BY feature_key`)
+      .all<any>();
+
+    return (results ?? []).map((row) => ({
+      key: row.feature_key,
+      enabled: !!row.enabled,
+      description: row.description ?? "",
     }));
   }
 }

--- a/workers-backend/src/telegram/webhook.ts
+++ b/workers-backend/src/telegram/webhook.ts
@@ -1,4 +1,4 @@
-import type { UserRepository } from "../storage/contracts";
+import type { ApiTokenService, CreditService, GptHistoryService, UserService } from "../services/user-services";
 
 interface TelegramUpdate {
   message?: {
@@ -6,30 +6,118 @@ interface TelegramUpdate {
     from?: { id: number; username?: string; first_name?: string };
     chat?: { id: number };
   };
+  callback_query?: {
+    id: string;
+    data?: string;
+    from?: { id: number; username?: string; first_name?: string };
+    message?: { chat?: { id: number } };
+  };
 }
 
-export async function handleTelegramWebhook(update: TelegramUpdate, deps: { botToken: string; users: UserRepository }) {
-  const message = update.message;
-  if (!message?.from || !message.chat) return { ok: true };
+interface TelegramDeps {
+  botToken: string;
+  users: UserService;
+  credits: CreditService;
+  tokens: ApiTokenService;
+  history: GptHistoryService;
+}
 
-  const user = await deps.users.upsertTelegramUser({
+export async function handleTelegramWebhook(update: TelegramUpdate, deps: TelegramDeps) {
+  if (update.callback_query?.id) {
+    await answerCallbackQuery(deps.botToken, update.callback_query.id, "✅ Received. More flows coming soon.");
+    return { handled: "callback_query" };
+  }
+
+  const message = update.message;
+  if (!message?.from || !message.chat) return { handled: "ignored" };
+
+  const user = await deps.users.bootstrapTelegramUser({
     userId: message.from.id,
     username: message.from.username,
     firstName: message.from.first_name,
   });
 
   const text = (message.text ?? "").trim();
+  if (!text) return { handled: "empty_message" };
+
   if (text === "/start") {
-    await sendTelegramMessage(deps.botToken, message.chat.id, `👋 Welcome ${user.firstName ?? ""}`.trim());
+    await sendTelegramMessage(
+      deps.botToken,
+      message.chat.id,
+      [
+        `👋 Welcome ${user.firstName ?? ""}`.trim(),
+        "Commands:",
+        "/profile - view your profile",
+        "/credits - view your credit balance",
+        "/apitoken - show your API token",
+        "/rotatetoken - rotate your API token",
+        "/history - show GPT history",
+        "/resethistory - clear GPT history",
+      ].join("\n")
+    );
+    return { handled: "/start" };
   }
 
-  return { ok: true };
+  if (text === "/profile") {
+    await sendTelegramMessage(
+      deps.botToken,
+      message.chat.id,
+      `🧾 Profile\nID: ${user.userId}\nUsername: @${user.username ?? "-"}\nName: ${user.firstName ?? "-"}\nLang: ${user.lang}`
+    );
+    return { handled: "/profile" };
+  }
+
+  if (text === "/credits") {
+    const credits = await deps.credits.getCredits(user.userId);
+    await sendTelegramMessage(deps.botToken, message.chat.id, `💳 Credits: ${credits.credits}`);
+    return { handled: "/credits" };
+  }
+
+  if (text === "/apitoken") {
+    const token = await deps.tokens.getOrCreate(user.userId);
+    await sendTelegramMessage(deps.botToken, message.chat.id, `🔑 API token:\n\`${token}\``, "Markdown");
+    return { handled: "/apitoken" };
+  }
+
+  if (text === "/rotatetoken") {
+    const token = await deps.tokens.rotate(user.userId);
+    await sendTelegramMessage(deps.botToken, message.chat.id, `♻️ New API token:\n\`${token}\``, "Markdown");
+    return { handled: "/rotatetoken" };
+  }
+
+  if (text === "/history") {
+    const messages = await deps.history.list(user.userId, 10);
+    if (messages.length === 0) {
+      await sendTelegramMessage(deps.botToken, message.chat.id, "🗂 GPT history is empty.");
+      return { handled: "/history_empty" };
+    }
+
+    const lines = messages.slice(-10).map((m, i) => `${i + 1}. [${m.role}] ${m.content.slice(0, 120)}`);
+    await sendTelegramMessage(deps.botToken, message.chat.id, `🗂 GPT history\n${lines.join("\n")}`);
+    return { handled: "/history" };
+  }
+
+  if (text === "/resethistory") {
+    await deps.history.clear(user.userId);
+    await sendTelegramMessage(deps.botToken, message.chat.id, "🧹 GPT history reset.");
+    return { handled: "/resethistory" };
+  }
+
+  return { handled: "unmapped_text" };
 }
 
-async function sendTelegramMessage(botToken: string, chatId: number, text: string) {
+async function sendTelegramMessage(botToken: string, chatId: number, text: string, parseMode?: "Markdown" | "HTML") {
   await fetch(`https://api.telegram.org/bot${botToken}/sendMessage`, {
     method: "POST",
     headers: { "content-type": "application/json" },
-    body: JSON.stringify({ chat_id: chatId, text }),
+    body: JSON.stringify({ chat_id: chatId, text, parse_mode: parseMode }),
+  });
+}
+
+async function answerCallbackQuery(botToken: string, callbackQueryId: string, text: string) {
+  await fetch(`https://api.telegram.org/bot${botToken}/answerCallbackQuery`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ callback_query_id: callbackQueryId, text, show_alert: false }),
   });
 }

--- a/workers-backend/tsconfig.json
+++ b/workers-backend/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["@cloudflare/workers-types"],
+    "lib": ["ES2022", "WebWorker"],
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/workers-backend/wrangler.toml
+++ b/workers-backend/wrangler.toml
@@ -2,10 +2,14 @@ name = "vexa-shared-backend"
 main = "src/index.ts"
 compatibility_date = "2026-04-18"
 
+[vars]
+SESSION_TTL_SECONDS = "2592000"
+
 [[d1_databases]]
 binding = "DB"
 database_name = "vexa"
 database_id = "REPLACE_WITH_D1_ID"
+migrations_dir = "migrations"
 
 [[durable_objects.bindings]]
 name = "USER_STATE"


### PR DESCRIPTION
### Motivation
- Replace the Python polling-first bot and local sqlite runtime with a single Cloudflare Workers–first shared backend that serves the Telegram bot (webhook), Telegram Mini App, and a future website.
- Provide real, transport-agnostic service APIs for user profile, credits, API tokens, GPT history, and generated assets backed by Cloudflare-native storage (D1 and Durable Objects).
- Harden Mini App auth so `initData` is validated correctly and returns a usable session token, and ensure webhook-based Telegram bot flows exist (not polling).
- Make the repository unambiguous about the new primary runtime, provide developer/deploy tooling, and document remaining parity work.

### Description
- Added a full TypeScript Workers backend under `workers-backend/` including route dispatch and HTTP helpers (`src/index.ts`, `src/http/*`, `src/routes/*`).
- Implemented public and authenticated routes: `GET /v1/health`, `GET /v1/features`, `GET /v1/telegram/webhook-info`, `POST /v1/auth/telegram-miniapp`, and the `/v1/me*` surface (`/credits`, `/api-token`, `/api-token/rotate`, `/gpt-history`, `/assets`).
- Reworked Telegram handling to webhook mode with richer command support and callback_query acknowledgement in `src/telegram/webhook.ts` and added an explicit webhook route `POST /telegram/webhook/<TELEGRAM_WEBHOOK_SECRET>`.
- Introduced domain service layer and D1-backed repositories (`src/services/*`, `src/storage/d1-repositories.ts`) and expanded the D1 schema and migrations (`workers-backend/migrations/0001_initial.sql`) to cover users, api tokens, sessions, GPT messages, generated assets, user state, credit ledger, and feature flags.
- Implemented Mini App `initData` validation that verifies signature, freshness, and parses the `user` payload then issues a D1-backed session token (`src/auth/telegram.ts` and `src/routes/public-routes.ts`).
- Added CORS helpers, consistent JSON success/error envelopes, session+API token resolution (`src/http/*`, `src/http/auth.ts`), Durable Object class `UserStateDO` exposure, and a `wrangler.toml` + `package.json` + `tsconfig.json` for local dev and D1 migrations.
- Updated documentation and README to declare Workers as the primary runtime, document local dev, D1 and Durable Object setup, exact webhook setup steps, and mark the Python stack as legacy reference; simplified `requirements.txt` to legacy-only notes.

### Testing
- Committed the changes and created the migration commit (commit recorded locally during the rollout). This validated the modified file set via `git` operations.
- Attempted `npm install` in `workers-backend/` in this environment but it failed with `403 Forbidden` from the npm registry, so dependency install and `tsc`/type-check could not be executed here.
- No CI `tsc` or runtime tests were executed in this environment due to the package install failure; the codepaths and routes were exercised through static inspection only as part of the rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e3e75db57c83319179da3820b6d83f)