### PR TITLE
Close endpoint-discovery and auth-flow gaps in Workers backend

### DIFF
--- a/src/routes/me-routes.ts
+++ b/src/routes/me-routes.ts
@@ -8,6 +8,7 @@ export async function handleMeRoutes(ctx: RouteCtx): Promise<Response | null> {
   if (!url.pathname.startsWith("/v1/me")) return null;
 
   const userId = await requireAuthedUserId(request, services);
+  await services.users.ensureActiveUser(userId);
   await services.users.touchLastSeen(userId);
 
   if (request.method === "GET" && url.pathname === "/v1/me") {

--- a/src/routes/public-routes.ts
+++ b/src/routes/public-routes.ts
@@ -1,5 +1,5 @@
 import { validateTelegramInitData } from "../auth/telegram";
-import { jsonOk, parseJsonBody } from "../http/response";
+import { HttpError, jsonOk, parseJsonBody } from "../http/response";
 import type { RouteCtx } from "./types";
 
 export async function handlePublicRoutes(ctx: RouteCtx): Promise<Response | null> {
@@ -14,10 +14,16 @@ export async function handlePublicRoutes(ctx: RouteCtx): Promise<Response | null
     return jsonOk({
       features: flags,
       routes: {
+        health: "/v1/health",
+        features: "/v1/features",
+        publicFeatures: "/v1/public/features",
+        telegramWebhookInfo: "/v1/telegram/webhook-info",
         telegramWebhook: "/telegram/webhook/<TELEGRAM_WEBHOOK_SECRET>",
         miniAppAuth: "/miniapp/auth/telegram",
+        telegramMiniAppAuthAlias: "/v1/auth/telegram-miniapp",
         me: "/v1/me",
         meCredits: "/v1/me/credits",
+        meCreditsLedger: "/v1/me/credits/ledger",
         meApiToken: "/v1/me/api-token",
         meApiTokenRotate: "/v1/me/api-token/rotate",
         meGptHistory: "/v1/me/gpt-history",
@@ -46,15 +52,16 @@ export async function handlePublicRoutes(ctx: RouteCtx): Promise<Response | null
     const body = await parseJsonBody<{ initData?: string }>(request);
     const identity = await validateTelegramInitData(body.initData ?? "", env.TELEGRAM_BOT_TOKEN);
 
-    await services.users.bootstrapTelegramUser({
+    const profile = await services.users.bootstrapTelegramUser({
       userId: identity.telegramUserId,
       username: identity.username,
       firstName: identity.firstName,
     });
+    if (profile.banned) throw new HttpError(403, "forbidden", "User is banned");
 
-    const ttlSeconds = Number(env.SESSION_TTL_SECONDS ?? "2592000");
+    const parsedTtlSeconds = Number(env.SESSION_TTL_SECONDS ?? "2592000");
+    const ttlSeconds = Number.isFinite(parsedTtlSeconds) && parsedTtlSeconds > 0 ? Math.floor(parsedTtlSeconds) : 2592000;
     const session = await services.sessions.createSession(identity.telegramUserId, "telegram_mini_app", ttlSeconds);
-    const profile = await services.users.getProfile(identity.telegramUserId);
 
     return jsonOk({
       accessToken: session.sessionToken,

--- a/src/services/user-services.ts
+++ b/src/services/user-services.ts
@@ -28,6 +28,12 @@ export class UserService {
   touchLastSeen(userId: number) {
     return this.users.touchLastSeen(userId);
   }
+
+  async ensureActiveUser(userId: number) {
+    const profile = await this.getProfile(userId);
+    if (profile.banned) throw new HttpError(403, "forbidden", "User is banned");
+    return profile;
+  }
 }
 
 export class CreditService {


### PR DESCRIPTION
### Motivation
- Complete a self-audit for the Cloudflare Workers cutover and remove gaps between implemented routes and advertised discovery metadata. 
- Harden auth/session behavior so banned users cannot obtain or use sessions and so malformed `SESSION_TTL_SECONDS` values cannot produce invalid expiries. 
- Keep Python archived in `legacy/` and ensure no Python code remains in the active production path.

### Description
- Expanded the `/v1/features` and `/v1/public/features` discovery payload to explicitly advertise `GET /v1/health`, `GET /v1/features`, `GET /v1/public/features`, `GET /v1/telegram/webhook-info`, the mini-app auth alias (`/v1/auth/telegram-miniapp`), and the credits ledger route (`/v1/me/credits/ledger`) in `src/routes/public-routes.ts`. 
- Added a reusable guard `UserService.ensureActiveUser(userId)` to enforce banned-user denial in `src/services/user-services.ts`. 
- Enforced banned-user rejection during Mini App auth/session issuance (`POST /miniapp/auth/telegram` / alias) and on all `/v1/me*` authenticated routes by invoking `ensureActiveUser`, in `src/routes/public-routes.ts` and `src/routes/me-routes.ts`. 
- Hardened session TTL parsing when creating mini-app sessions so `SESSION_TTL_SECONDS` is validated and falls back to `2592000` if malformed or non-positive, in `src/routes/public-routes.ts`.

### Testing
- Ran static type check via `npm run check` (invokes `tsc --noEmit`), which failed due to inability to fetch `@cloudflare/workers-types` from the registry in this environment (registry access `403 Forbidden`). 
- Attempted `npm install`, which failed with the same registry access restriction preventing installation of `@cloudflare/workers-types`. 
- Verified file-level diffs and local TypeScript source changes by inspection and lint-style checks (`rg`/`sed`/`nl`) to confirm the new guards and advertised routes are wired into the request handling flow and the Worker entrypoint (`src/index.ts`) constructs services using the modified `UserService`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e3ef27b3308331a61cefcd78adf115)