### PR TITLE
Add D1 runtime-consistency migration and improve deploy readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,20 +53,49 @@ npm run d1:migrate:local
 npm run dev
 ```
 
-## Infrastructure setup
+## D1 setup (required before deploy)
+
+Create D1 once:
 
 ```bash
 wrangler d1 create vexa
 ```
 
-Copy the returned `database_id` into `wrangler.toml` under `[[d1_databases]]`.
+Then copy the returned `database_id` into `wrangler.toml` under `[[d1_databases]]`:
 
-Set secrets/vars:
+- Replace `__REPLACE_WITH_D1_DATABASE_ID__` with your real D1 ID.
+- `npm run deploy` and `npm run d1:migrate:remote` will fail until this is replaced.
+
+## D1 migrations
+
+Apply local migrations:
+
+```bash
+npm run d1:migrate:local
+# equivalent:
+# wrangler d1 migrations apply vexa --local
+```
+
+Apply remote (production) migrations:
+
+```bash
+npm run d1:migrate:remote
+# equivalent:
+# wrangler d1 migrations apply vexa --remote
+```
+
+## Required secrets
+
+Set required secrets:
 
 ```bash
 wrangler secret put TELEGRAM_BOT_TOKEN
 wrangler secret put TELEGRAM_WEBHOOK_SECRET
-# optional owner escalation destination
+```
+
+Optional secret for owner escalation notifications:
+
+```bash
 wrangler secret put OWNER_TELEGRAM_CHAT_ID
 ```
 
@@ -86,3 +115,12 @@ npm run check
 npm run d1:migrate:remote
 npm run deploy
 ```
+
+## Pre-deploy checklist (minimum)
+
+- [ ] D1 database created (`wrangler d1 create vexa`)
+- [ ] `wrangler.toml` updated with real `database_id`
+- [ ] Migrations applied locally and remotely
+- [ ] Required secrets set (`TELEGRAM_BOT_TOKEN`, `TELEGRAM_WEBHOOK_SECRET`)
+- [ ] Optional `OWNER_TELEGRAM_CHAT_ID` set if owner notifications are needed
+- [ ] `npm run deploy` executed

--- a/migrations/0003_runtime_consistency.sql
+++ b/migrations/0003_runtime_consistency.sql
@@ -1,0 +1,36 @@
+-- Runtime consistency patch for Cloudflare Workers migration.
+-- Ensures tables used by current repositories exist in every environment.
+
+CREATE TABLE IF NOT EXISTS telegram_webhook_events (
+  update_id INTEGER PRIMARY KEY,
+  telegram_user_id INTEGER,
+  event_type TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS owner_notifications (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER REFERENCES users(user_id) ON DELETE SET NULL,
+  source TEXT NOT NULL,
+  category TEXT NOT NULL,
+  message TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'queued',
+  created_at INTEGER NOT NULL,
+  delivered_at INTEGER
+);
+
+-- Query helpers for webhook/event inspection and owner escalation workflows.
+CREATE INDEX IF NOT EXISTS idx_telegram_webhook_events_event_created
+  ON telegram_webhook_events(event_type, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_telegram_webhook_events_user_created
+  ON telegram_webhook_events(telegram_user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_owner_notifications_status_created
+  ON owner_notifications(status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_owner_notifications_recent
+  ON owner_notifications(created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_owner_notifications_user_created
+  ON owner_notifications(user_id, created_at DESC);

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,7 +8,9 @@ SESSION_TTL_SECONDS = "2592000"
 [[d1_databases]]
 binding = "DB"
 database_name = "vexa"
-database_id = "REPLACE_WITH_D1_ID"
+database_id = "__REPLACE_WITH_D1_DATABASE_ID__"
+# Replace with the real ID from: wrangler d1 create vexa
+# Deploy and remote migrations will fail until this value is updated.
 migrations_dir = "migrations"
 
 [[durable_objects.bindings]]


### PR DESCRIPTION
### Motivation

- Ensure runtime-required D1 tables used by the Workers code exist and are indexed so the migration and runtime are consistent.
- Prevent accidental remote-deploy failures by making the `database_id` placeholder explicit and improving deploy documentation and checklist.

### Description

- Added `migrations/0003_runtime_consistency.sql` which creates `telegram_webhook_events` (with `update_id` primary key, optional `telegram_user_id`, `event_type`, `created_at`) and `owner_notifications` (autoincrement `id`, optional `user_id`, `source`, `category`, `message`, `status`, `created_at`, optional `delivered_at`) plus useful indexes.
- Replaced the vague D1 placeholder in `wrangler.toml` with `__REPLACE_WITH_D1_DATABASE_ID__` and added comments clarifying that `database_id` must be replaced before remote migrations/deploys, while keeping `migrations_dir = "migrations"` intact.
- Updated `README.md` to document D1 setup (`wrangler d1 create vexa`), exact local/remote migration commands (`npm run d1:migrate:local` / `npm run d1:migrate:remote`), required secrets (`TELEGRAM_BOT_TOKEN`, `TELEGRAM_WEBHOOK_SECRET` and optional `OWNER_TELEGRAM_CHAT_ID`), and a pre-deploy checklist.
- Audited repository usage and migrations to ensure tables referenced by `src/storage/d1-repositories.ts` are present in migrations and confirmed no other schema/column mismatches were found.

### Testing

- Ran a repository-to-migration audit with `rg -n "telegram_webhook_events|owner_notifications" src/storage/d1-repositories.ts migrations/*.sql` which confirmed the tables are present in migrations and referenced by the repositories.
- Added and committed the new migration and changed files to the repo (git commit succeeded locally).
- Ran `npm run check` which could not complete in this environment due to missing `@cloudflare/workers-types` type resolution and therefore failed the type-check step.
- Ran `npm install` which could not complete in this environment due to a 403 fetching `@cloudflare/workers-types` from the npm registry, so a full build could not be verified here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e3f1fcb8a483318a628b01108e4c5a)