### PR TITLE
Fix Durable Object runtime compatibility for UserStateDO

### DIFF
--- a/src/storage/user-state-do.ts
+++ b/src/storage/user-state-do.ts
@@ -1,8 +1,14 @@
+import { DurableObject } from "cloudflare:workers";
+
 /**
  * Per-user strongly consistent state.
  * Intended for flows like in-progress Telegram conversation/session state.
  */
 export class UserStateDO extends DurableObject {
+  constructor(ctx: DurableObjectState, env: unknown) {
+    super(ctx, env);
+  }
+
   async fetch(request: Request): Promise<Response> {
     const url = new URL(request.url);
 


### PR DESCRIPTION
### Motivation

- Resolve deployment error `ReferenceError: DurableObject is not defined` by adapting the Durable Object class to the module-runtime-compatible pattern.

### Description

- Imported `DurableObject` from `cloudflare:workers` and added a constructor that forwards `ctx`/`env` to `super(...)` in `src/storage/user-state-do.ts` (only file changed), which fixes the error by avoiding reliance on a missing global while keeping the class name `UserStateDO` and the `USER_STATE` binding intact.

### Testing

- Ran `npm run check` which failed because `@cloudflare/workers-types` could not be installed due to a registry `403` so type-checking could not complete, and no additional automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e3f6bb83708331a5059a0273a9784f)