### PR TITLE
Add Telegram webhook setup helper and README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ wrangler secret put OWNER_TELEGRAM_CHAT_ID
 
 ## Telegram webhook setup
 
+Run the helper (recommended):
+
+```bash
+TELEGRAM_BOT_TOKEN=... TELEGRAM_WEBHOOK_SECRET=... ./scripts/setup-telegram-webhook.sh
+```
+
+Or call Telegram API manually:
+
 ```bash
 npm run deploy
 curl "https://api.telegram.org/bot<TELEGRAM_BOT_TOKEN>/setWebhook?url=<WORKER_BASE_URL>/telegram/webhook/<TELEGRAM_WEBHOOK_SECRET>"

--- a/scripts/setup-telegram-webhook.sh
+++ b/scripts/setup-telegram-webhook.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WORKER_BASE_URL="${WORKER_BASE_URL:-https://vexaai.vexaagent.workers.dev}"
+WEBHOOK_SECRET="${TELEGRAM_WEBHOOK_SECRET:-}"
+BOT_TOKEN="${TELEGRAM_BOT_TOKEN:-}"
+
+if [[ -z "$BOT_TOKEN" ]]; then
+  echo "ERROR: TELEGRAM_BOT_TOKEN is required in environment." >&2
+  exit 1
+fi
+
+if [[ -z "$WEBHOOK_SECRET" ]]; then
+  echo "ERROR: TELEGRAM_WEBHOOK_SECRET is required in environment." >&2
+  exit 1
+fi
+
+WEBHOOK_URL="${WORKER_BASE_URL}/telegram/webhook/${WEBHOOK_SECRET}"
+SET_URL="https://api.telegram.org/bot${BOT_TOKEN}/setWebhook"
+INFO_URL="https://api.telegram.org/bot${BOT_TOKEN}/getWebhookInfo"
+
+echo "Setting Telegram webhook to: ${WEBHOOK_URL}"
+set_response="$(curl -sS --get "$SET_URL" --data-urlencode "url=${WEBHOOK_URL}")"
+echo "setWebhook response:"
+echo "$set_response"
+
+echo
+info_response="$(curl -sS "$INFO_URL")"
+echo "getWebhookInfo response:"
+echo "$info_response"


### PR DESCRIPTION
### Motivation

- Make it easy and safe to configure the Telegram webhook for the deployed Cloudflare Worker without hardcoding secrets.  
- Provide an idempotent, reproducible way to set `setWebhook` and immediately verify via `getWebhookInfo`.  
- Ensure the repository documents the recommended workflow for operators to avoid secret leakage or manual errors.

### Description

- Add `scripts/setup-telegram-webhook.sh` which sets the Telegram webhook using environment variables `TELEGRAM_BOT_TOKEN`, `TELEGRAM_WEBHOOK_SECRET`, and optional `WORKER_BASE_URL`, and then fetches `getWebhookInfo` for verification.  
- Update `README.md` to recommend the helper command `TELEGRAM_BOT_TOKEN=... TELEGRAM_WEBHOOK_SECRET=... ./scripts/setup-telegram-webhook.sh` as the preferred setup path.  
- Confirmed the runtime webhook route is `POST /telegram/webhook/${env.TELEGRAM_WEBHOOK_SECRET}` as implemented in `src/routes/telegram-routes.ts` and that the Worker expects `TELEGRAM_BOT_TOKEN` and `TELEGRAM_WEBHOOK_SECRET` in the environment via `src/routes/types.ts`.  
- Generated a safe random webhook secret to use if not already set: `47bcf36021b04cb64fddac38c9b473d2b8838b06ba3b949ab728a849033bde4d` (set this value in the Worker secret named `TELEGRAM_WEBHOOK_SECRET`).

### Testing

- Ran `bash -n scripts/setup-telegram-webhook.sh` to validate script syntax, which succeeded.  
- Executing `./scripts/setup-telegram-webhook.sh` in this environment failed by design because `TELEGRAM_BOT_TOKEN` was not provided, which the script correctly detects and errors on.  
- Attempted to query the live Worker (`curl https://vexaai.vexaagent.workers.dev/v1/telegram/webhook-info`) and call Telegram APIs from this runner, but these network calls failed due to proxy/connectivity restrictions in the execution environment, so live `setWebhook`/`getWebhookInfo` verification was not performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e3fb6a9c208331b75527b8143aa4ca)