### PR TITLE
Restore legacy main/admin menu behavior in Workers bot

### DIFF
--- a/src/services/telegram-bot-service.ts
+++ b/src/services/telegram-bot-service.ts
@@ -1429,6 +1429,14 @@ ${ADMIN_MENU_TEXT}`, this.adminMenuKeyboard(), messageId);
             inline_keyboard: [
               [{ text: "➕ افزودن", callback_data: `admin:uadd:${u.user_id}` }, { text: "➖ کسر", callback_data: `admin:usub:${u.user_id}` }],
               [{ text: "✉️ پیام تکی", callback_data: `admin:dm:${u.user_id}` }, { text: u.banned ? "✅ آن‌بن" : "🚫 بن", callback_data: `admin:${u.banned ? "unban" : "ban"}:${u.user_id}` }],
+              [
+                { text: "📥 متن‌های TTS کاربر", callback_data: `admin:exp_user_tts:${u.user_id}` },
+                { text: "💬 پیام‌های کاربر", callback_data: `admin:exp_user_msgs:${u.user_id}` },
+              ],
+              [
+                { text: "🤖 GPT کاربر", callback_data: `admin:exp_user_gpt:${u.user_id}` },
+                { text: "🖼️ تصاویر کاربر", callback_data: `admin:exp_user_images:${u.user_id}` },
+              ],
               [{ text: "⬅️ بازگشت", callback_data: "admin:users" }],
             ],
           };
@@ -1749,11 +1757,6 @@ ${ADMIN_MENU_TEXT}`, this.adminMenuKeyboard(), messageId);
         ],
         [{ text: t("btn_tts", lang), callback_data: "home:tts" }],
         [{ text: t("btn_gpt", lang), callback_data: "home:gpt_chat" }],
-        [
-          { text: t("btn_image", lang), callback_data: "home:image" },
-          { text: t("btn_video", lang), callback_data: "home:video" },
-        ],
-        [{ text: t("btn_sora2", lang), callback_data: "home:sora2" }],
         [
           { text: t("btn_lang", lang), callback_data: "home:lang" },
           { text: t("btn_invite", lang), callback_data: "home:invite" },


### PR DESCRIPTION
### Motivation
- Restore legacy Telegram bot behavior for the main menu and admin per-user actions so the current Workers-based bot matches the legacy Python product surface and callbacks.
- Ensure users and admins see the same menu items, button order and per-user export actions that existed in `legacy/` while keeping Cloudflare Workers + D1 architecture unchanged.

### Description
- Restored the legacy main menu layout in `src/services/telegram-bot-service.ts` by removing the non-legacy `image`, `video` and `sora2` rows so the menu now matches legacy ordering (Profile/Credit → TTS → GPT → Language/Invite) via `mainMenuKeyboard`.
- Restored per-user admin action buttons in `src/services/telegram-bot-service.ts` user profile keyboard by adding callbacks for `admin:exp_user_tts`, `admin:exp_user_msgs`, `admin:exp_user_gpt`, and `admin:exp_user_images` so admin export actions mirror legacy behavior.
- Only file changed: `src/services/telegram-bot-service.ts`, and all changes preserve the current Workers runtime, routes and D1 usage (behavioral parity only).

### Testing
- Ran TypeScript checks via `npm run check`; the command failed with pre-existing TypeScript errors unrelated to this PR (errors in `src/auth/telegram.ts` and `src/storage/user-state-do.ts`), and the menu/admin surface changes themselves produce no runtime TypeScript errors in the edited file.
- No additional automated test suite exists for these UI/keyboard parity changes, so verification was by static build/test and focused code inspection of the updated handlers and keyboards.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e626d73d908331b0e290ec88869a7b)